### PR TITLE
fix: competitionsテーブルの一部のカラムの型変更

### DIFF
--- a/db/migrate/20240413013515_change_column_types_for_competitions.rb
+++ b/db/migrate/20240413013515_change_column_types_for_competitions.rb
@@ -1,0 +1,15 @@
+class ChangeColumnTypesForCompetitions < ActiveRecord::Migration[7.0]
+  def change
+    def up
+      change_column :competitions, :category, :string
+      change_column :competitions, :age_group, :string
+      change_column :competitions, :weight_class, :string
+    end
+
+    def down
+      change_column :competitions, :category, :integer
+      change_column :competitions, :age_group, :integer
+      change_column :competitions, :weight_class, :integer
+    end
+  end
+end

--- a/db/migrate/20240413013918_change_column_types_for_competitions_fix.rb
+++ b/db/migrate/20240413013918_change_column_types_for_competitions_fix.rb
@@ -1,0 +1,13 @@
+class ChangeColumnTypesForCompetitionsFix < ActiveRecord::Migration[7.0]
+  def up
+    change_column :competitions, :category, :string
+    change_column :competitions, :age_group, :string
+    change_column :competitions, :weight_class, :string
+  end
+
+  def down
+    change_column :competitions, :category, :integer
+    change_column :competitions, :age_group, :integer
+    change_column :competitions, :weight_class, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_10_111128) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_13_013918) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,9 +21,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_10_111128) do
     t.date "date", null: false
     t.integer "competition_type", null: false
     t.integer "gearcategory_type", null: false
-    t.integer "category", null: false
-    t.integer "age_group", null: false
-    t.integer "weight_class", null: false
+    t.string "category", null: false
+    t.string "age_group", null: false
+    t.string "weight_class", null: false
     t.integer "participation_status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
以下のカラムをint型からstring型に修正した
category(大会カテゴリ),
age_group(年齢別区分),
weight_class(階級別区分)

理由
ルール変更により、enum定義の中身が削除されたり追加されたりする可能性があるため。
enumだと柔軟な対応が難しいと考えられるため
代わりにstring型にして、文字列の定数はmodelファイル内に記載。

feature #8