### PR TITLE
fix: 大会情報詳細、試技結果詳細ページのレイアウト調整

### DIFF
--- a/app/views/competition_records/_competition_record.html.erb
+++ b/app/views/competition_records/_competition_record.html.erb
@@ -1,89 +1,161 @@
-<p>
-  <strong>検量体重</strong>
-  <%= competition_record.weight %>kg
-</p>
-<p>
-  <strong>スクワット第１試技</strong>
-  <%= competition_record.squat_first_attempt %>kg
-</p>
-<p>
-  <strong>スクワット第１試技判定結果</strong>
-  <%= competition_record.squat_first_attempt_result %>
-</p>
-<p>
-  <strong>スクワット第2試技</strong>
-  <%= competition_record.squat_second_attempt %>kg
-</p>
-<p>
-  <strong>スクワット第2試技判定結果</strong>
-  <%= competition_record.squat_second_attempt_result %>
-</p>
-<p>
-  <strong>スクワット第3試技</strong>
-  <%= competition_record.squat_third_attempt %>kg
-</p>
-<p>
-  <strong>スクワット第3試技判定結果</strong>
-  <%= competition_record.squat_third_attempt_result %>
-</p>
-<p>
-  <strong>ベンチプレス第１試技</strong>
-  <%= competition_record.benchpress_first_attempt %>kg
-</p>
-<p>
-  <strong>ベンチプレス第１試技判定結果</strong>
-  <%= competition_record.benchpress_first_attempt_result %>
-</p>
-<p>
-  <strong>ベンチプレス第2試技</strong>
-  <%= competition_record.benchpress_second_attempt %>kg
-</p>
-<p>
-  <strong>ベンチプレス第2試技判定結果</strong>
-  <%= competition_record.benchpress_second_attempt_result %>
-</p>
-<p>
-  <strong>ベンチプレス第3試技</strong>
-  <%= competition_record.benchpress_third_attempt %>kg
-</p>
-<p>
-  <strong>ベンチプレス第3試技判定結果</strong>
-  <%= competition_record.benchpress_third_attempt_result %>
-</p>
-<p>
-  <strong>デッドリフト第１試技</strong>
-  <%= competition_record.deadlift_first_attempt %>kg
-</p>
-<p>
-  <strong>デッドリフト第１試技判定結果</strong>
-  <%= competition_record.deadlift_first_attempt_result %>
-</p>
-<p>
-  <strong>デッドリフト第2試技</strong>
-  <%= competition_record.deadlift_second_attempt %>kg
-</p>
-<p>
-  <strong>デッドリフト第2試技判定結果</strong>
-  <%= competition_record.deadlift_second_attempt_result %>
-</p>
-<p>
-  <strong>デッドリフト第3試技</strong>
-  <%= competition_record.deadlift_third_attempt %>kg
-</p>
-<p>
-  <strong>デッドリフト第3試技判定結果</strong>
-  <%= competition_record.deadlift_third_attempt_result %>
-</p>
-<p>
-  <strong>コメント</strong>
-  <%= simple_format(h(competition_record.comment)) %>
-</p>
-<button class="btn btn-primary">
-  <%= link_to "大会結果の編集", edit_competition_competition_record_path(competition) %>
-</button>
-<button class="btn btn-primary">
-  <li><%= link_to "試技結果削除", competition_competition_record_path(competition), data: {
-                    turbo_method: :delete,
-                    turbo_confirm: "削除しますか？"
-                  } %></li>
-</button>
+<div class="card-body max-w-72 min-w-72">
+  <div class="flex justify-center">
+    <h1 class="card-title text-center">
+      試技結果
+    </h1>
+  </div>
+  <div class="border-b-2 border-dashed py-2">
+    <h2 class="font-bold"><%= CompetitionRecord.human_attribute_name(:weight) %>:</h2>
+    <p class="text-sm"> <%= competition_record.weight %> kg</p>
+  </div>
+  <!-- SQ試技結果 -->
+  <div class="border-b-2 border-dashed py-2">
+    <h2 class="font-bold pb-1">スクワット</h2>
+    <!-- SQ第１試技 -->
+    <div class="flex flex-row pb-1">
+      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
+      <p class="text-sm basis-1/3 text-right"> <%= competition_record.squat_first_attempt %> kg</p>
+      <!-- 判定結果 -->
+      <% if competition_record.squat_first_success? %>
+        <p class="text-sm basis-1/3 text-right text-green-500">
+      <% elsif competition_record.squat_first_failure? %>
+        <p class="text-sm basis-1/3 text-right text-red-500">
+      <% elsif competition_record.squat_first_not_attempted? %>
+        <p class="text-sm basis-1/3 text-right text-gray-500">
+      <% end %> 
+        <%= competition_record.squat_first_attempt_result_i18n %>
+      </p>
+    </div>
+    <!-- SQ第2試技 -->
+    <div class="flex flex-row pb-1">
+      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.second_attempt') %> </h3>
+      <p class="text-sm basis-1/3 text-right"> <%= competition_record.squat_second_attempt %> kg</p>
+      <!-- 判定結果 -->
+      <% if competition_record.squat_second_success? %>
+        <p class="text-sm basis-1/3 text-right text-green-500">
+      <% elsif competition_record.squat_second_failure? %>
+        <p class="text-sm basis-1/3 text-right text-red-500">
+      <% elsif competition_record.squat_second_not_attempted? %>
+        <p class="text-sm basis-1/3 text-right text-gray-500">
+      <% end %> 
+        <%= competition_record.squat_second_attempt_result_i18n %>
+      </p>
+    </div>
+     <!-- SQ第3試技 -->
+    <div class="flex flex-row pb-1">
+      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.third_attempt') %> </h3>
+      <p class="text-sm basis-1/3 text-right"> <%= competition_record.squat_third_attempt %> kg</p>
+      <!-- 判定結果 -->
+      <% if competition_record.squat_third_success? %>
+        <p class="text-sm basis-1/3 text-right text-green-500">
+      <% elsif competition_record.squat_third_failure? %>
+        <p class="text-sm basis-1/3 text-right text-red-500">
+      <% elsif competition_record.squat_third_not_attempted? %>
+        <p class="text-sm basis-1/3 text-right text-gray-500">
+      <% end %> 
+        <%= competition_record.squat_third_attempt_result_i18n %>
+      </p>
+    </div>
+  </div>
+  <!-- BP試技結果 -->
+  <div class="border-b-2 border-dashed py-2">
+    <h2 class="font-bold pb-1">ベンチプレス</h2>
+    <!-- BP第１試技 -->
+    <div class="flex flex-row pb-1">
+      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
+      <p class="text-sm basis-1/3 text-right"> <%= competition_record.benchpress_first_attempt %> kg</p>
+      <!-- 判定結果 -->
+      <% if competition_record.benchpress_first_success? %>
+        <p class="text-sm basis-1/3 text-right text-green-500">
+      <% elsif competition_record.benchpress_first_failure? %>
+        <p class="text-sm basis-1/3 text-right text-red-500">
+      <% elsif competition_record.benchpress_first_not_attempted? %>
+        <p class="text-sm basis-1/3 text-right text-gray-500">
+      <% end %>
+        <%= competition_record.benchpress_first_attempt_result_i18n %>
+      </p>
+    </div>
+    <!-- BP第2試技 -->
+    <div class="flex flex-row pb-1">
+      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.second_attempt') %> </h3>
+      <p class="text-sm basis-1/3 text-right"> <%= competition_record.benchpress_second_attempt %> kg</p>
+      <!-- 判定結果 -->
+      <% if competition_record.benchpress_second_success? %>
+        <p class="text-sm basis-1/3 text-right text-green-500">
+      <% elsif competition_record.benchpress_second_failure? %>
+        <p class="text-sm basis-1/3 text-right text-red-500">
+      <% elsif competition_record.benchpress_second_not_attempted? %>
+        <p class="text-sm basis-1/3 text-right text-gray-500">
+      <% end %>
+        <%= competition_record.benchpress_second_attempt_result_i18n %>
+      </p>
+    </div>
+    <!-- BP第3試技 -->
+    <div class="flex flex-row pb-1">
+      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.third_attempt') %> </h3>
+      <p class="text-sm basis-1/3 text-right"> <%= competition_record.benchpress_third_attempt %> kg</p>
+      <!-- 判定結果 -->
+      <% if competition_record.benchpress_third_success? %>
+        <p class="text-sm basis-1/3 text-right text-green-500">
+      <% elsif competition_record.benchpress_third_failure? %>
+        <p class="text-sm basis-1/3 text-right text-red-500">
+      <% elsif competition_record.benchpress_third_not_attempted? %>
+        <p class="text-sm basis-1/3 text-right text-gray-500">
+      <% end %> 
+        <%= competition_record.benchpress_third_attempt_result_i18n %>
+      </p>
+    </div>
+  </div>
+  <!-- DL試技結果 -->
+  <div class="border-b-2 border-dashed py-2">
+    <h2 class="font-bold pb-1">デッドリフト</h2>
+    <!-- DL第１試技 -->
+    <div class="flex flex-row pb-1">
+      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
+      <p class="text-sm basis-1/3 text-right"> <%= competition_record.deadlift_first_attempt %> kg</p>
+      <!-- 判定結果 -->
+      <% if competition_record.deadlift_first_success? %>
+        <p class="text-sm basis-1/3 text-right text-green-500">
+      <% elsif competition_record.deadlift_first_failure? %>
+        <p class="text-sm basis-1/3 text-right text-red-500">
+      <% elsif competition_record.deadlift_first_not_attempted? %>
+        <p class="text-sm basis-1/3 text-right text-gray-500">
+      <% end %>
+        <%= competition_record.deadlift_first_attempt_result_i18n %>
+      </p>
+    </div>
+    <!-- DL第2試技 -->
+    <div class="flex flex-row pb-1">
+      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.second_attempt') %> </h3>
+      <p class="text-sm basis-1/3 text-right"> <%= competition_record.deadlift_second_attempt %> kg</p>
+      <!-- 判定結果 -->
+      <% if competition_record.deadlift_second_success? %>
+        <p class="text-sm basis-1/3 text-right text-green-500">
+      <% elsif competition_record.deadlift_second_failure? %>
+        <p class="text-sm basis-1/3 text-right text-red-500">
+      <% elsif competition_record.deadlift_second_not_attempted? %>
+        <p class="text-sm basis-1/3 text-right text-gray-500">
+      <% end %>
+        <%= competition_record.deadlift_second_attempt_result_i18n %>
+      </p>
+    </div>
+    <!-- DLDL第3試技 -->
+    <div class="flex flex-row pb-1">
+      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.third_attempt') %> </h3>
+      <p class="text-sm basis-1/3 text-right"> <%= competition_record.deadlift_third_attempt %> kg</p>
+      <!-- 判定結果 -->
+      <% if competition_record.deadlift_third_success? %>
+        <p class="text-sm basis-1/3 text-right text-green-500">
+      <% elsif competition_record.deadlift_third_failure? %>
+        <p class="text-sm basis-1/3 text-right text-red-500">
+      <% elsif competition_record.deadlift_third_not_attempted? %>
+        <p class="text-sm basis-1/3 text-right text-gray-500">
+      <% end %> 
+        <%= competition_record.deadlift_third_attempt_result_i18n %>
+      </p>
+    </div>
+  </div>
+  <button class="btn btn-primary">
+    <%= link_to "大会結果の編集", edit_competition_competition_record_path(competition) %>
+  </button>
+</div>

--- a/app/views/competition_records/_competition_record.html.erb
+++ b/app/views/competition_records/_competition_record.html.erb
@@ -1,3 +1,6 @@
+<div class="flex justify-end items-center w-full">
+  <%= link_to "試技結果削除", competition_competition_record_path(competition), data: {turbo_method: :delete, turbo_confirm: "削除しますか？"}, class: "btn btn-sm btn-error max-w-24" %>
+</div>
 <div class="card-body max-w-72 min-w-72">
   <div class="flex justify-center">
     <h1 class="card-title text-center">
@@ -22,7 +25,7 @@
         <p class="text-sm basis-1/3 text-right text-red-500">
       <% elsif competition_record.squat_first_not_attempted? %>
         <p class="text-sm basis-1/3 text-right text-gray-500">
-      <% end %> 
+      <% end %>
         <%= competition_record.squat_first_attempt_result_i18n %>
       </p>
     </div>
@@ -37,11 +40,11 @@
         <p class="text-sm basis-1/3 text-right text-red-500">
       <% elsif competition_record.squat_second_not_attempted? %>
         <p class="text-sm basis-1/3 text-right text-gray-500">
-      <% end %> 
+      <% end %>
         <%= competition_record.squat_second_attempt_result_i18n %>
       </p>
     </div>
-     <!-- SQ第3試技 -->
+    <!-- SQ第3試技 -->
     <div class="flex flex-row pb-1">
       <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.third_attempt') %> </h3>
       <p class="text-sm basis-1/3 text-right"> <%= competition_record.squat_third_attempt %> kg</p>
@@ -52,7 +55,7 @@
         <p class="text-sm basis-1/3 text-right text-red-500">
       <% elsif competition_record.squat_third_not_attempted? %>
         <p class="text-sm basis-1/3 text-right text-gray-500">
-      <% end %> 
+      <% end %>
         <%= competition_record.squat_third_attempt_result_i18n %>
       </p>
     </div>
@@ -155,7 +158,15 @@
       </p>
     </div>
   </div>
-  <button class="btn btn-primary">
-    <%= link_to "大会結果の編集", edit_competition_competition_record_path(competition) %>
-  </button>
+  <!-- コメント -->
+  <div class="border-b-2 border-dashed py-2">
+    <h2 class="font-bold pb-1">コメント</h2>
+    <!-- 振り返りコメント -->
+    <div class="rounded border border-gray-400 text-sm">
+      <%= simple_format(h(competition_record.comment)) %>
+    </div>
+  </div>
+  <div class="flex-col flex justify-center items-center w-full">
+    <%= link_to "大会結果の編集", edit_competition_competition_record_path(competition), class: "btn btn-sm btn-primary max-w-24"  %>
+  </div>
 </div>

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -1,55 +1,39 @@
-<div id="<%= dom_id @competition %>">
-  <p>
-    <strong>Name:</strong>
-    <%= @competition.name %>
-  </p>
-  <p>
-    <strong>Venue:</strong>
-    <%= @competition.venue %>
-  </p>
-  <p>
-    <strong>Date:</strong>
-    <%= @competition.date %>
-  </p>
-  <p>
-    <strong>competition_type:</strong>
-    <%= @competition.competition_type_i18n %>
-  </p>
-  <p>
-    <strong>Gearcategory_type:</strong>
-    <%= @competition.gearcategory_type_i18n %>
-  </p>
-  <p>
-    <strong>Category:</strong>
-    <%= @competition.category %>
-  </p>
-  <p>
-    <strong>Age_group:</strong>
-    <%= @competition.age_group %>
-  </p>
-  <p>
-    <strong>Weight_class:</strong>
-    <%= @competition.weight_class %>
-  </p>
-  <p>
-    <strong>Participation_status:</strong>
-    <%= @competition.participation_status_i18n %>
-  </p>
-  <button class="btn btn-primary">
-    <%= link_to "大会結果記録", new_competition_competition_record_path(@competition) %>
-  </button>
-  <button class="btn btn-primary">
-    <%= link_to "編集", edit_competition_path(@competition) %>
-  </button>
-  <button class="btn btn-primary">
-    <li><%= link_to "削除", competition_path(@competition), data: {turbo_method: :delete, turbo_confirm: "削除しますか？"} %></li>
-  </button>
-  <p>
-    <strong>---------------</strong>
-  </p>
-  <% if CompetitionRecord.exists?(competition_id: @competition.id) %>
-	  <%= render 'competition_records/competition_record', competition_record: @competition_record, competition: @competition%>
-  <% else %>
-    <p>大会結果記録はまだ未登録です</p>
-  <% end %>
+<div class="hero min-h-screen bg-base-200">
+  <div class="hero-content flex-col">
+    <div class="card flex items-center mx-auto max-w-80 bg-white shadow-xl p-4">
+      <div class="card-body">
+        <h1 class="card-title flex items-center gap-2 text-2xl font-semibold leading-10 mb-4">
+          <%= @competition.name %>
+        </h1>
+        <p class="mb-2">
+          <span class="font-bold"><%= Competition.human_attribute_name(:venue) %>:</span>
+          <%= @competition.venue %>
+        </p>
+        <p class="mb-2">
+            <span class="font-bold"><%= Competition.human_attribute_name(:date) %>:</span>
+            <%= @competition.date %>
+        </p>
+        <p class="border-t border-gray-300 pt-4 mt-4 mb-2">
+            <span class="font-bold"><%= Competition.human_attribute_name(:competition_type) %>:</span>
+            <%= @competition.competition_type_i18n %>
+        </p>
+        <p class="mb-2">
+            <span class="font-bold"><%= Competition.human_attribute_name(:gearcategory_type) %>:</span>
+            <%= @competition.gearcategory_type_i18n %>
+        </p>
+        <p class="mb-2">
+            <span class="font-bold"><%= Competition.human_attribute_name(:category) %>:</span>
+            <%= @competition.category %>
+        </p>
+        <p class="mb-2">
+            <span class="font-bold"><%= Competition.human_attribute_name(:age_group) %>:</span>
+            <%= @competition.age_group %>
+        </p>
+        <p class="mb-4">
+            <span class="font-bold"><%= Competition.human_attribute_name(:weight_class) %>:</span>
+            <%= @competition.weight_class %>
+        </p>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -1,6 +1,6 @@
 <div class="hero min-h-screen bg-base-200">
   <div class="hero-content flex-col">
-    <div class="card items-center mx-auto max-w-80 bg-white shadow-xl p-4">
+    <div class="card items-center mx-auto max-w-80 min-w-80 bg-white shadow-xl p-4">
       <div class="flex justify-end items-center w-full">
         <%= link_to "削除", competition_path(@competition), data: {turbo_method: :delete, turbo_confirm: "削除しますか？"}, class: "btn btn-sm btn-error max-w-24" %>
       </div>
@@ -40,6 +40,17 @@
           <%= link_to "編集", edit_competition_path(@competition), class: "btn btn-sm btn-primary max-w-24" %>
         </div>
       </div>
+    </div>
+    <!-- 大会試技結果詳細情報 -->
+    <div class="card items-center mx-auto max-w-80 min-w-80 bg-white shadow-xl p-4">
+      <% if CompetitionRecord.exists?(competition_id: @competition.id) %>
+	      <%= render 'competition_records/competition_record', competition_record: @competition_record, competition: @competition%>
+      <% else %>
+        <div class="flex-col flex justify-center items-center w-full">
+          <p>大会結果記録はまだ未登録です</p>
+          <%= link_to "大会結果記録", new_competition_competition_record_path(@competition), class: "btn btn-sm btn-primary max-w-24" %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -2,37 +2,37 @@
   <div class="hero-content flex-col">
     <div class="card flex items-center mx-auto max-w-80 bg-white shadow-xl p-4">
       <div class="card-body">
-        <h1 class="card-title flex items-center gap-2 text-2xl font-semibold leading-10 mb-4">
+        <h1 class="card-title text-center">
           <%= @competition.name %>
         </h1>
-        <p class="mb-2">
-          <span class="font-bold"><%= Competition.human_attribute_name(:venue) %>:</span>
-          <%= @competition.venue %>
-        </p>
-        <p class="mb-2">
-            <span class="font-bold"><%= Competition.human_attribute_name(:date) %>:</span>
-            <%= @competition.date %>
-        </p>
-        <p class="border-t border-gray-300 pt-4 mt-4 mb-2">
-            <span class="font-bold"><%= Competition.human_attribute_name(:competition_type) %>:</span>
-            <%= @competition.competition_type_i18n %>
-        </p>
-        <p class="mb-2">
-            <span class="font-bold"><%= Competition.human_attribute_name(:gearcategory_type) %>:</span>
-            <%= @competition.gearcategory_type_i18n %>
-        </p>
-        <p class="mb-2">
-            <span class="font-bold"><%= Competition.human_attribute_name(:category) %>:</span>
-            <%= @competition.category %>
-        </p>
-        <p class="mb-2">
-            <span class="font-bold"><%= Competition.human_attribute_name(:age_group) %>:</span>
-            <%= @competition.age_group %>
-        </p>
-        <p class="mb-4">
-            <span class="font-bold"><%= Competition.human_attribute_name(:weight_class) %>:</span>
-            <%= @competition.weight_class %>
-        </p>
+        <div class="border-b-2 border-dashed py-2">
+          <h2 class="font-bold"><%= Competition.human_attribute_name(:venue) %>:</h2>
+          <p class="text-sm"> <%= @competition.venue %>あああああああああああああああああああああああああ </p>
+        </div>
+        <div class="border-b-2 border-dashed py-2">
+          <h2 class="font-bold"><%= Competition.human_attribute_name(:date) %>:</h2>
+          <p class="text-sm"> <%= @competition.date %> </p>
+        </div>
+        <div class="border-b-2 border-dashed py-2">
+          <h2 class="font-bold"><%= Competition.human_attribute_name(:competition_type) %>:</h2>
+          <p class="text-sm"> <%= @competition.competition_type_i18n %> </p>
+        </div>
+        <div class="border-b-2 border-dashed py-2">
+          <h2 class="font-bold"><%= Competition.human_attribute_name(:gearcategory_type) %>:</h2>
+          <p class="text-sm"> <%= @competition.gearcategory_type_i18n %> </p>
+        </div>
+        <div class="border-b-2 border-dashed py-2">
+          <h2 class="font-bold"><%= Competition.human_attribute_name(:category) %>:</h2>
+          <p class="text-sm"> <%= @competition.category %> </p>
+        </div>
+        <div class="border-b-2 border-dashed py-2">
+          <h2 class="font-bold"><%= Competition.human_attribute_name(:age_group) %>:</h2>
+          <p class="text-sm"> <%= @competition.age_group %> </p>
+        </div>
+        <div class="border-b-2 border-dashed py-2">
+          <h2 class="font-bold"><%= Competition.human_attribute_name(:weight_class) %>:</h2>
+          <p class="text-sm"> <%= @competition.weight_class %> </p>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -1,13 +1,16 @@
 <div class="hero min-h-screen bg-base-200">
   <div class="hero-content flex-col">
-    <div class="card flex items-center mx-auto max-w-80 bg-white shadow-xl p-4">
+    <div class="card items-center mx-auto max-w-80 bg-white shadow-xl p-4">
+      <div class="flex justify-end items-center w-full">
+        <%= link_to "削除", competition_path(@competition), data: {turbo_method: :delete, turbo_confirm: "削除しますか？"}, class: "btn btn-sm btn-error max-w-24" %>
+      </div>
       <div class="card-body">
         <h1 class="card-title text-center">
           <%= @competition.name %>
         </h1>
         <div class="border-b-2 border-dashed py-2">
           <h2 class="font-bold"><%= Competition.human_attribute_name(:venue) %>:</h2>
-          <p class="text-sm"> <%= @competition.venue %>あああああああああああああああああああああああああ </p>
+          <p class="text-sm"> <%= @competition.venue %></p>
         </div>
         <div class="border-b-2 border-dashed py-2">
           <h2 class="font-bold"><%= Competition.human_attribute_name(:date) %>:</h2>
@@ -32,6 +35,9 @@
         <div class="border-b-2 border-dashed py-2">
           <h2 class="font-bold"><%= Competition.human_attribute_name(:weight_class) %>:</h2>
           <p class="text-sm"> <%= @competition.weight_class %> </p>
+        </div>
+        <div class="flex justify-center items-center w-full">
+          <%= link_to "編集", edit_competition_path(@competition), class: "btn btn-sm btn-primary max-w-24" %>
         </div>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,9 @@
       <%= render "shared/before_login_header" %>
     <% end %>
     <!-- ヘッダー -->
-    <%= yield %>
+    <div class="pb-16">
+      <%= yield %>
+    </div>
     <!-- フッターとボトムナビゲーション -->
     <% if logged_in? %>
       <% if @show_bottom_nav %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,4 +1,4 @@
-<div class="navbar bg-base-100">
+<div class="navbar bg-base-100 sticky top-0 z-50">
   <div class="flex-1">
     <%= link_to "good lifter log", root_path, class:"btn btn-ghost text-xl" %>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="navbar bg-base-100">
+<div class="navbar bg-base-100 sticky top-0 z-50">
   <div class="flex-1">
     <%= link_to "good lifter log", root_path, class:"btn btn-ghost text-xl" %>
   </div>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -17,6 +17,10 @@ ja:
     new:
       title: ユーザー登録
       to_login_page: ログインページへ
+  competition_record:
+    first_attempt: "第1試技"
+    second_attempt: "第2試技"
+    third_attempt: "第3試技"
   header:
     login: ログイン
     logout: ログアウト


### PR DESCRIPTION
## 変更の概要

* 変更の概要
* feature #9 
* close #9
* スマホ画面のみ対応だが大会情報詳細ページのレイアウト調整をした
* 試技結果も大会情報の下にそのまま配置させることにした
  -   画面遷移の数が多くなるのを避けるため


## 課題

* 試技結果の詳細（各競技、各試技で何KGあげたか)よりも、
  各試技の最高成功重量とそれらの合計重量が大会の成績として１番知りたいかも
* 各試技の最高成功重量とそれらの合計重量の計算機能を追加したとき、再度試技結果の詳細を別画面遷移して
表示するのか考えたい
