### PR TITLE
fix: 大会情報一覧と詳細ページのレイアウト崩れを修正

### DIFF
--- a/app/views/competition_records/_competition_record.html.erb
+++ b/app/views/competition_records/_competition_record.html.erb
@@ -1,6 +1,3 @@
-<div class="flex justify-end items-center w-full">
-  <%= link_to "試技結果削除", competition_competition_record_path(competition), data: {turbo_method: :delete, turbo_confirm: "削除しますか？"}, class: "btn btn-sm btn-error max-w-24" %>
-</div>
 <div class="card-body max-w-72 min-w-72">
   <div class="flex justify-center">
     <h1 class="card-title text-center">
@@ -153,7 +150,7 @@
         <p class="text-sm basis-1/3 text-right text-red-500">
       <% elsif competition_record.deadlift_third_not_attempted? %>
         <p class="text-sm basis-1/3 text-right text-gray-500">
-      <% end %> 
+      <% end %>
         <%= competition_record.deadlift_third_attempt_result_i18n %>
       </p>
     </div>
@@ -166,7 +163,8 @@
       <%= simple_format(h(competition_record.comment)) %>
     </div>
   </div>
-  <div class="flex-col flex justify-center items-center w-full">
-    <%= link_to "大会結果の編集", edit_competition_competition_record_path(competition), class: "btn btn-sm btn-primary max-w-24"  %>
+  <div class="flex justify-end w-full">
+    <%= link_to "編集", edit_competition_competition_record_path(competition), class: "btn btn-sm btn-primary max-w-24 mx-2" %>
+    <%= link_to "削除", competition_competition_record_path(competition), data: {turbo_method: :delete, turbo_confirm: "削除しますか？"}, class: "btn btn-sm btn-error max-w-24" %>
   </div>
 </div>

--- a/app/views/competitions/_competition.html.erb
+++ b/app/views/competitions/_competition.html.erb
@@ -2,7 +2,7 @@
     <tbody class="divide-y divide-gray-100 border-t border-gray-100 text-xs">
       <tr class="hover:bg-gray-50">
         <td class="text-left px-4 py-4 text-gray-900"><%= competition.date %></td>
-        <td class="text-left px-4 py-4"><%= competition.name %></td>
+        <td class="text-left px-4 py-4 w-48"><%= competition.name %></td>
         <td class="px-4 py-4">
           <%= link_to "詳細", competition_path(competition), class: "btn btn-sm text-xs" %>
         </td>

--- a/app/views/competitions/index.html.erb
+++ b/app/views/competitions/index.html.erb
@@ -1,5 +1,5 @@
-<div class="min-h-screen bg-base-200">
-  <div class="hero-content flex-col w-full">
+<div class="hero min-h-screen bg-base-200">
+  <div class="hero-content flex-col">
       <!-- 大会結果一覧 -->
     <h1 class="text-2xl">出場済大会の一覧</h1>
     <div class="w-full mx-auto max-w-full overflow-auto">
@@ -7,7 +7,7 @@
         <thead class="bg-gray-50">
           <tr>
             <th scope="col" class="px-4 py-4 font-medium text-gray-900"><%= Competition.human_attribute_name("date") %></th>
-            <th scope="col" class="px-4 py-4 font-medium text-gray-900"><%= Competition.human_attribute_name("name") %></th>
+            <th scope="col" class="px-4 py-4 font-medium text-gray-900 w-48"><%= Competition.human_attribute_name("name") %></th>
             <th scope="col" class="px-4 py-4 font-medium text-gray-900"></th>
           </tr>
         </thead>

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -1,13 +1,12 @@
 <div class="hero min-h-screen bg-base-200">
   <div class="hero-content flex-col">
     <div class="card items-center mx-auto max-w-80 min-w-80 bg-white shadow-xl p-4">
-      <div class="flex justify-end items-center w-full">
-        <%= link_to "削除", competition_path(@competition), data: {turbo_method: :delete, turbo_confirm: "削除しますか？"}, class: "btn btn-sm btn-error max-w-24" %>
-      </div>
-      <div class="card-body">
-        <h1 class="card-title text-center">
-          <%= @competition.name %>
-        </h1>
+      <div class="card-body max-w-72 min-w-72">
+        <div class="flex justify-center">
+          <h1 class="card-title text-center">
+            <%= @competition.name %>
+          </h1>
+        </div>
         <div class="border-b-2 border-dashed py-2">
           <h2 class="font-bold"><%= Competition.human_attribute_name(:venue) %>:</h2>
           <p class="text-sm"> <%= @competition.venue %></p>
@@ -36,8 +35,9 @@
           <h2 class="font-bold"><%= Competition.human_attribute_name(:weight_class) %>:</h2>
           <p class="text-sm"> <%= @competition.weight_class %> </p>
         </div>
-        <div class="flex justify-center items-center w-full">
-          <%= link_to "編集", edit_competition_path(@competition), class: "btn btn-sm btn-primary max-w-24" %>
+        <div class="flex justify-end w-full">
+          <%= link_to "編集", edit_competition_path(@competition), class: "btn btn-sm btn-primary max-w-24 mx-2" %>
+          <%= link_to "削除", competition_path(@competition), data: {turbo_method: :delete, turbo_confirm: "削除しますか？"}, class: "btn btn-sm btn-error max-w-24" %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 変更の概要

* 変更の概要
- 大会情報一覧ページ
   表をブラウザの真ん中にもってくる
   大会名の長さに合わせてテーブルの幅が変わるのを修正する
- 大会情報詳細ページ
   削除ボタンを、詳細ボタンの横に配置
   大会名の長さに合わせてテーブルの幅が変わるのを修正する

* 関連するIssueやプルリクエスト
feature #103
close #103
 
## なぜこの変更をするのか

削除ボタンの位置を、左上にしていたが無意識に触ってしまうため

