### PR TITLE
fix: 試技結果記録・編集フォームのレイアウト崩れ対応

### DIFF
--- a/app/views/competition_records/_form.html.erb
+++ b/app/views/competition_records/_form.html.erb
@@ -1,180 +1,137 @@
 <%= form_with model: competition_record, url: competition_competition_record_path(competition)  do |f| %>
 	<label class="form-control w-full mb-6">
 		<div class="label p-0 flex justify-start items-center">
-			<%= f.label :weight %>
+			<%= f.label :weight, class: 'mr-2'%>
 			<p class="text-red-500">(必須)</p>
 		</div>
 		<%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-full', placeholder:"検量体重", required: true %>
 	</label>
 	<!-- スクワット試技結果 -->
 	<!-- スクワット第１試技 -->
-	<div class="flex justify-between gap-x-9 mb-6">
-		<label class="form-control flex-grow">
-			<div class="label p-0 flex justify-start items-center">
-				<%= f.label :squat_first_attempt %>
-			</div>
-				<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded max-w-xs', placeholder:"重量を入力してください" %>
-		</label>
-		<label class="form-control flex-grow">
-			<div class="label p-0 flex justify-start items-center">
-				<%= f.label :squat_first_attempt_result %>
-			</div>
-				<%= f.select :squat_first_attempt_result,
-				CompetitionRecord.squat_first_attempt_results_i18n.invert.map{|key, value| [key, value]},
-				{include_blank: '判定結果'},
-				{ class: 'select select-bordered rounded select-sm w-36 max-w-xs' } %>
-		</label>
-	</div>
+	<div class="flex justify-between mb-6">
+    <label class="form-control flex-grow">
+      <%= f.label :squat_first_attempt %>
+      <%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+    </label>
+    <label class="form-control flex-grow">
+      <%= f.label :squat_first_attempt_result %>
+      <%= f.select :squat_first_attempt_result,
+      CompetitionRecord.squat_first_attempt_results_i18n.invert.map { |key, value| [key, value] },
+      {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+    </label>
+  </div>
 	<!-- スクワット第2試技 -->
-	<div class="flex justify-between gap-x-9 mb-6">
-			<label class="form-control flex-grow">
-				<div class="label p-0 flex justify-start items-center">
-					<%= f.label :squat_second_attempt %>
-				</div>
-					<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded max-w-xs', placeholder:"重量を入力してください" %>
-			</label>
-			<label class="form-control flex-grow">
-				<div class="label p-0 flex justify-start items-center">
-					<%= f.label :squat_second_attempt_result %>
-				</div>
-					<%= f.select :squat_second_attempt_result,
-					CompetitionRecord.squat_second_attempt_results_i18n.invert.map{|key, value| [key, value]},
-					{include_blank: '判定結果'},
-					{ class: 'select select-bordered rounded select-sm w-36 max-w-xs' } %>
-			</label>
-	</div>
+  <div class="flex justify-between mb-6">
+    <label class="form-control flex-grow">
+      <%= f.label :squat_second_attempt %>
+      <%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+    </label>
+    <label class="form-control flex-grow">
+      <%= f.label :squat_second_attempt_result %>
+      <%= f.select :squat_second_attempt_result,
+      CompetitionRecord.squat_second_attempt_results_i18n.invert.map { |key, value| [key, value] },
+      {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+    </label>
+  </div>
 	<!-- スクワット第3試技 -->
-	<div class="flex justify-between gap-x-9 mb-6">
-			<label class="form-control flex-grow">
-				<div class="label p-0 flex justify-start items-center">
-					<%= f.label :squat_third_attempt %>
-				</div>
-					<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded max-w-xs', placeholder:"重量を入力してください" %>
-			</label>
-			<label class="form-control flex-grow">
-				<div class="label p-0 flex justify-start items-center">
-					<%= f.label :squat_third_attempt_result %>
-				</div>
-					<%= f.select :squat_third_attempt_result,
-					CompetitionRecord.squat_third_attempt_results_i18n.invert.map{|key, value| [key, value]},
-					{include_blank: '判定結果'},
-					{ class: 'select select-bordered rounded select-sm w-36 max-w-xs' } %>
-			</label>
-	</div>
+  <div class="flex justify-between mb-6">
+    <label class="form-control flex-grow">
+      <%= f.label :squat_third_attempt %>
+      <%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+    </label>
+    <label class="form-control flex-grow">
+      <%= f.label :squat_third_attempt_result %>
+      <%= f.select :squat_third_attempt_result,
+      CompetitionRecord.squat_third_attempt_results_i18n.invert.map { |key, value| [key, value] },
+      {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+    </label>
+  </div>
 	<!-- ベンチプレス試技結果 -->
 	<!-- ベンチプレス第１試技 -->
-	<div class="flex justify-between gap-x-9 mb-6">
-		<label class="form-control flex-grow">
-			<div class="label p-0 flex justify-start items-center">
-				<%= f.label :benchpress_first_attempt %>
-			</div>
-				<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded max-w-xs', placeholder:"重量を入力してください" %>
-		</label>
-		<label class="form-control flex-grow">
-			<div class="label p-0 flex justify-start items-center">
-				<%= f.label :benchpress_first_attempt_result %>
-			</div>
-				<%= f.select :benchpress_first_attempt_result,
-				CompetitionRecord.benchpress_first_attempt_results_i18n.invert.map{|key, value| [key, value]},
-				{include_blank: '判定結果'},
-				{ class: 'select select-bordered rounded select-sm w-36 max-w-xs' } %>
-		</label>
-	</div>
+  <div class="flex justify-between mb-6">
+    <label class="form-control flex-grow">
+      <%= f.label :benchpress_first_attempt %>
+      <%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+    </label>
+    <label class="form-control flex-grow">
+      <%= f.label :benchpress_first_attempt_result %>
+      <%= f.select :benchpress_first_attempt_result,
+      CompetitionRecord.benchpress_first_attempt_results_i18n.invert.map { |key, value| [key, value] },
+      {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+    </label>
+  </div>
 	<!-- ベンチプレス第2試技 -->
-	<div class="flex justify-between gap-x-9 mb-6">
-		<label class="form-control flex-grow">
-			<div class="label p-0 flex justify-start items-center">
-				<%= f.label :benchpress_second_attempt %>
-			</div>
-				<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded max-w-xs', placeholder:"重量を入力してください" %>
-		</label>
-		<label class="form-control flex-grow">
-			<div class="label p-0 flex justify-start items-center">
-				<%= f.label :benchpress_second_attempt_result %>
-			</div>
-				<%= f.select :benchpress_second_attempt_result,
-				CompetitionRecord.benchpress_second_attempt_results_i18n.invert.map{|key, value| [key, value]},
-				{include_blank: '判定結果'},
-				{ class: 'select select-bordered rounded select-sm w-36 max-w-xs' } %>
-		</label>
-	</div>
+  <div class="flex justify-between mb-6">
+    <label class="form-control flex-grow">
+      <%= f.label :benchpress_second_attempt %>
+      <%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+    </label>
+    <label class="form-control flex-grow">
+      <%= f.label :benchpress_second_attempt_result %>
+      <%= f.select :benchpress_second_attempt_result,
+      CompetitionRecord.benchpress_second_attempt_results_i18n.invert.map { |key, value| [key, value] },
+      {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+    </label>
+  </div>
 	<!-- ベンチプレス第3試技 -->
-	<div class="flex justify-between gap-x-9 mb-6">
-		<label class="form-control flex-grow">
-			<div class="label p-0 flex justify-start items-center">
-				<%= f.label :benchpress_third_attempt %>
-			</div>
-				<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded max-w-xs', placeholder:"重量を入力してください" %>
-		</label>
-		<label class="form-control flex-grow">
-			<div class="label p-0 flex justify-start items-center">
-				<%= f.label :benchpress_third_attempt_result %>
-			</div>
-				<%= f.select :benchpress_third_attempt_result,
-				CompetitionRecord.benchpress_third_attempt_results_i18n.invert.map{|key, value| [key, value]},
-				{include_blank: '判定結果'},
-				{ class: 'select select-bordered rounded select-sm w-36 max-w-xs' } %>
-		</label>
-	</div>
-
+  <div class="flex justify-between mb-6">
+    <label class="form-control flex-grow">
+      <%= f.label :benchpress_third_attempt %>
+      <%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+    </label>
+    <label class="form-control flex-grow">
+      <%= f.label :benchpress_third_attempt_result %>
+      <%= f.select :benchpress_third_attempt_result,
+      CompetitionRecord.benchpress_third_attempt_results_i18n.invert.map { |key, value| [key, value] },
+      {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+    </label>
+  </div>
 	<!-- デッドリフト試技結果 -->
 	<!-- デッドリフト第１試技 -->
-	<div class="flex justify-between gap-x-9 mb-6">
-		<label class="form-control flex-grow">
-			<div class="label p-0 flex justify-start items-center">
-				<%= f.label :deadlift_first_attempt %>
-			</div>
-				<%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded max-w-xs', placeholder:"重量を入力してください" %>
-		</label>
-		<label class="form-control flex-grow">
-			<div class="label p-0 flex justify-start items-center">
-				<%= f.label :deadlift_first_attempt_result %>
-			</div>
-				<%= f.select :deadlift_first_attempt_result,
-				CompetitionRecord.deadlift_first_attempt_results_i18n.invert.map{|key, value| [key, value]},
-				{include_blank: '判定結果'},
-				{ class: 'select select-bordered rounded select-sm w-36 max-w-xs' } %>
-		</label>
-	</div>
+  <div class="flex justify-between mb-6">
+    <label class="form-control flex-grow">
+      <%= f.label :deadlift_first_attempt %>
+      <%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+    </label>
+    <label class="form-control flex-grow">
+      <%= f.label :deadlift_first_attempt_result %>
+      <%= f.select :deadlift_first_attempt_result,
+      CompetitionRecord.deadlift_first_attempt_results_i18n.invert.map { |key, value| [key, value] },
+      {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+    </label>
+  </div>
 	<!-- デッドリフト第2試技 -->
-	<div class="flex justify-between gap-x-9 mb-6">
-		<label class="form-control flex-grow">
-			<div class="label p-0 flex justify-start items-center">
-				<%= f.label :deadlift_second_attempt %>
-			</div>
-				<%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded max-w-xs', placeholder:"重量を入力してください" %>
-		</label>
-		<label class="form-control flex-grow">
-			<div class="label p-0 flex justify-start items-center">
-				<%= f.label :deadlift_second_attempt_result %>
-			</div>
-				<%= f.select :deadlift_second_attempt_result,
-				CompetitionRecord.deadlift_second_attempt_results_i18n.invert.map{|key, value| [key, value]},
-				{include_blank: '判定結果'},
-				{ class: 'select select-bordered rounded select-sm w-36 max-w-xs' } %>
-		</label>
-	</div>
+  <div class="flex justify-between mb-6">
+    <label class="form-control flex-grow">
+      <%= f.label :deadlift_second_attempt %>
+      <%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+    </label>
+    <label class="form-control flex-grow">
+      <%= f.label :deadlift_second_attempt_result %>
+      <%= f.select :deadlift_second_attempt_result,
+      CompetitionRecord.deadlift_second_attempt_results_i18n.invert.map { |key, value| [key, value] },
+      {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+    </label>
+  </div>
 	<!-- デッドリフト第3試技 -->
-	<div class="flex justify-between gap-x-9 mb-6">
-		<label class="form-control flex-grow">
-			<div class="label p-0 flex justify-start items-center">
-				<%= f.label :deadlift_third_attempt %>
-			</div>
-				<%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded max-w-xs', placeholder:"重量を入力してください" %>
-		</label>
-		<label class="form-control flex-grow">
-			<div class="label p-0 flex justify-start items-center">
-				<%= f.label :deadlift_third_attempt_result %>
-			</div>
-				<%= f.select :deadlift_third_attempt_result,
-				CompetitionRecord.deadlift_second_attempt_results_i18n.invert.map{|key, value| [key, value]},
-				{include_blank: '判定結果'},
-				{ class: 'select select-bordered rounded select-sm w-36 max-w-xs' } %>
-		</label>
-	</div>
+  <div class="flex justify-between mb-6">
+    <label class="form-control flex-grow">
+      <%= f.label :deadlift_third_attempt %>
+      <%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+    </label>
+    <label class="form-control flex-grow">
+      <%= f.label :deadlift_third_attempt_result %>
+      <%= f.select :deadlift_third_attempt_result,
+      CompetitionRecord.deadlift_third_attempt_results_i18n.invert.map { |key, value| [key, value] },
+      {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+    </label>
+  </div>
 	<!-- 振り返りコメント -->
 	<label class="form-control mb-6">
-			<%= f.label :comment %>
+    <div class="label p-0 flex justify-start items-center">
+			<%= f.label :comment, class: 'mr-2'%>
+      <p class="text-slate-500">(任意)</p>
+    </div>
 			<%= f.text_area :comment, class:"textarea textarea-bordered", placeholder:"振り返りコメント" %>
 	</label>
 	<!-- ボタン -->
@@ -182,17 +139,3 @@
 			<%= f.submit class: 'btn btn-primary' %>
 	</div>
     <% end %>
-
-	<div class="join">
-  <div>
-    <div>
-      <input class="input input-bordered input-sm rounded w-full max-w-xs join-item" placeholder="Search"/>
-    </div>
-  </div>
-  <select class="select select-bordered select-sm w-full max-w-xs join-item">
-    <option disabled selected>Filter</option>
-    <option>Sci-fi</option>
-    <option>Drama</option>
-    <option>Action</option>
-  </select>
-</div>

--- a/app/views/competition_records/_form.html.erb
+++ b/app/views/competition_records/_form.html.erb
@@ -9,7 +9,7 @@
 	<!-- スクワット試技結果 -->
 	<!-- スクワット第１試技 -->
 	<div class="flex justify-between mb-6">
-    <label class="form-control flex-grow">
+    <label class="form-control flex-grow mr-2">
       <%= f.label :squat_first_attempt %>
       <%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
@@ -22,7 +22,7 @@
   </div>
 	<!-- スクワット第2試技 -->
   <div class="flex justify-between mb-6">
-    <label class="form-control flex-grow">
+    <label class="form-control flex-grow mr-2">
       <%= f.label :squat_second_attempt %>
       <%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
@@ -35,11 +35,11 @@
   </div>
 	<!-- スクワット第3試技 -->
   <div class="flex justify-between mb-6">
-    <label class="form-control flex-grow">
+    <label class="form-control flex-grow mr-2">
       <%= f.label :squat_third_attempt %>
       <%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
-    <label class="form-control flex-grow">
+    <label class="form-control flex-grow mr-2">
       <%= f.label :squat_third_attempt_result %>
       <%= f.select :squat_third_attempt_result,
       CompetitionRecord.squat_third_attempt_results_i18n.invert.map { |key, value| [key, value] },
@@ -49,7 +49,7 @@
 	<!-- ベンチプレス試技結果 -->
 	<!-- ベンチプレス第１試技 -->
   <div class="flex justify-between mb-6">
-    <label class="form-control flex-grow">
+    <label class="form-control flex-grow mr-2">
       <%= f.label :benchpress_first_attempt %>
       <%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
@@ -62,7 +62,7 @@
   </div>
 	<!-- ベンチプレス第2試技 -->
   <div class="flex justify-between mb-6">
-    <label class="form-control flex-grow">
+    <label class="form-control flex-grow mr-2">
       <%= f.label :benchpress_second_attempt %>
       <%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
@@ -75,7 +75,7 @@
   </div>
 	<!-- ベンチプレス第3試技 -->
   <div class="flex justify-between mb-6">
-    <label class="form-control flex-grow">
+    <label class="form-control flex-grow mr-2">
       <%= f.label :benchpress_third_attempt %>
       <%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
@@ -89,7 +89,7 @@
 	<!-- デッドリフト試技結果 -->
 	<!-- デッドリフト第１試技 -->
   <div class="flex justify-between mb-6">
-    <label class="form-control flex-grow">
+    <label class="form-control flex-grow mr-2">
       <%= f.label :deadlift_first_attempt %>
       <%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
@@ -102,7 +102,7 @@
   </div>
 	<!-- デッドリフト第2試技 -->
   <div class="flex justify-between mb-6">
-    <label class="form-control flex-grow">
+    <label class="form-control flex-grow mr-2">
       <%= f.label :deadlift_second_attempt %>
       <%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
@@ -115,7 +115,7 @@
   </div>
 	<!-- デッドリフト第3試技 -->
   <div class="flex justify-between mb-6">
-    <label class="form-control flex-grow">
+    <label class="form-control flex-grow mr-2">
       <%= f.label :deadlift_third_attempt %>
       <%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>

--- a/app/views/competition_records/_form.html.erb
+++ b/app/views/competition_records/_form.html.erb
@@ -1,3 +1,7 @@
+<article class="text-wrap text-center m-4">
+  <h1 class="font-semibold text-red-500">(※)試技結果の選択について</h1>
+  <p class="text-sm text-red-500">試技結果に重量を入力した場合、<br/>試技結果が成功か失敗か<br/>選択する必要があります。</p>
+</article>
 <%= form_with model: competition_record, url: competition_competition_record_path(competition)  do |f| %>
 	<label class="form-control w-full mb-6">
 		<div class="label p-0 flex justify-start items-center">
@@ -14,7 +18,10 @@
       <%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
     <label class="form-control flex-grow">
-      <%= f.label :squat_first_attempt_result %>
+      <div class="label p-0 flex justify-start items-center">
+        <%= f.label :squat_first_attempt_result, class: 'mr-2' %>
+        <p class="text-red-500">(※)</p>
+      </div>
       <%= f.select :squat_first_attempt_result,
       CompetitionRecord.squat_first_attempt_results_i18n.invert.map { |key, value| [key, value] },
       {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
@@ -27,7 +34,10 @@
       <%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
     <label class="form-control flex-grow">
-      <%= f.label :squat_second_attempt_result %>
+      <div class="label p-0 flex justify-start items-center">
+        <%= f.label :squat_second_attempt_result, class: 'mr-2' %>
+        <p class="text-red-500">(※)</p>
+      </div>
       <%= f.select :squat_second_attempt_result,
       CompetitionRecord.squat_second_attempt_results_i18n.invert.map { |key, value| [key, value] },
       {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
@@ -40,7 +50,10 @@
       <%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
     <label class="form-control flex-grow mr-2">
-      <%= f.label :squat_third_attempt_result %>
+      <div class="label p-0 flex justify-start items-center">
+        <%= f.label :squat_third_attempt_result, class: 'mr-2' %>
+        <p class="text-red-500">(※)</p>
+      </div>
       <%= f.select :squat_third_attempt_result,
       CompetitionRecord.squat_third_attempt_results_i18n.invert.map { |key, value| [key, value] },
       {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
@@ -54,7 +67,10 @@
       <%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
     <label class="form-control flex-grow">
-      <%= f.label :benchpress_first_attempt_result %>
+      <div class="label p-0 flex justify-start items-center">
+        <%= f.label :benchpress_first_attempt_result, class: 'mr-2' %>
+        <p class="text-red-500">(※)</p>
+      </div>
       <%= f.select :benchpress_first_attempt_result,
       CompetitionRecord.benchpress_first_attempt_results_i18n.invert.map { |key, value| [key, value] },
       {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
@@ -67,7 +83,10 @@
       <%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
     <label class="form-control flex-grow">
-      <%= f.label :benchpress_second_attempt_result %>
+      <div class="label p-0 flex justify-start items-center">
+        <%= f.label :benchpress_second_attempt_result, class: 'mr-2' %>
+        <p class="text-red-500">(※)</p>
+      </div>
       <%= f.select :benchpress_second_attempt_result,
       CompetitionRecord.benchpress_second_attempt_results_i18n.invert.map { |key, value| [key, value] },
       {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
@@ -80,7 +99,10 @@
       <%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
     <label class="form-control flex-grow">
-      <%= f.label :benchpress_third_attempt_result %>
+      <div class="label p-0 flex justify-start items-center">
+        <%= f.label :benchpress_third_attempt_result, class: 'mr-2' %>
+        <p class="text-red-500">(※)</p>
+      </div>
       <%= f.select :benchpress_third_attempt_result,
       CompetitionRecord.benchpress_third_attempt_results_i18n.invert.map { |key, value| [key, value] },
       {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
@@ -94,7 +116,10 @@
       <%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
     <label class="form-control flex-grow">
-      <%= f.label :deadlift_first_attempt_result %>
+      <div class="label p-0 flex justify-start items-center">
+        <%= f.label :deadlift_first_attempt_result, class: 'mr-2' %>
+        <p class="text-red-500">(※)</p>
+      </div>
       <%= f.select :deadlift_first_attempt_result,
       CompetitionRecord.deadlift_first_attempt_results_i18n.invert.map { |key, value| [key, value] },
       {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
@@ -107,7 +132,10 @@
       <%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
     <label class="form-control flex-grow">
-      <%= f.label :deadlift_second_attempt_result %>
+      <div class="label p-0 flex justify-start items-center">
+        <%= f.label :deadlift_second_attempt_result, class: 'mr-2' %>
+        <p class="text-red-500">(※)</p>
+      </div>
       <%= f.select :deadlift_second_attempt_result,
       CompetitionRecord.deadlift_second_attempt_results_i18n.invert.map { |key, value| [key, value] },
       {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
@@ -120,7 +148,10 @@
       <%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
     </label>
     <label class="form-control flex-grow">
-      <%= f.label :deadlift_third_attempt_result %>
+      <div class="label p-0 flex justify-start items-center">
+        <%= f.label :deadlift_third_attempt_result, class: 'mr-2' %>
+        <p class="text-red-500">(※)</p>
+      </div>
       <%= f.select :deadlift_third_attempt_result,
       CompetitionRecord.deadlift_third_attempt_results_i18n.invert.map { |key, value| [key, value] },
       {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>

--- a/app/views/competition_records/edit.html.erb
+++ b/app/views/competition_records/edit.html.erb
@@ -1,7 +1,10 @@
 <div class="hero min-h-screen bg-base-200">
-  <div class="hero-content flex-col lg:flex-row-reverse">
+  <div class="hero-content flex-col">
+    <div class="items-center mx-auto max-w-80 min-w-80">
+      <h1 class="text-2xl text-center">試技結果の編集</h1>
       <!-- ここからform_withを使う形に修正 -->
-    <%= render 'form', competition_record: @competition_record, competition: @competition %>
+      <%= render 'form', competition_record: @competition_record, competition: @competition %>
       <!-- ここまでform_withを使う形に修正 -->
+    </div>
   </div>
 </div>

--- a/app/views/competition_records/new.html.erb
+++ b/app/views/competition_records/new.html.erb
@@ -1,8 +1,10 @@
 <div class="hero min-h-screen bg-base-200">
   <div class="hero-content flex-col">
+    <div class="items-center mx-auto max-w-80 min-w-80">
       <!-- ここからform_withを使う形に修正 -->
-    <h1 class="text-2xl">試技結果の登録</h1>
-    <%= render 'form', competition_record: @competition_record, competition: @competition %>
+      <h1 class="text-2xl text-center">試技結果の登録</h1>
+      <%= render 'form', competition_record: @competition_record, competition: @competition %>
       <!-- ここまでform_withを使う形に修正 -->
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## 変更の概要

* 変更の概要

  -  入力フォームのレイアウト崩れを修正した
  - 何が任意で、何が必須入力項目か明確にした


* 関連するIssueやプルリクエスト
  feature #105 
  close #105 