### PR TITLE
fix: dbのvolumeプロパティのコンテナのパスを修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       TZ: Asia/Tokyo
       POSTGRES_PASSWORD: password
     volumes:
-      - postgresql_data:/var/lib/postgresql
+      - postgresql_data:/var/lib/postgresql/data
     ports:
       - 5432:5432
     healthcheck:


### PR DESCRIPTION
feature #125

## 変更の概要

* 変更の概要
- docker_compose.ymlファイルのdbのvolumeのパスを修正した
- dockerをリスタートするとデータベースの永続化ができないという不具合があったため

* 関連するIssueやプルリクエスト
close #125 
