### PR TITLE
add: usersのemailカラムにindexとunipue制約を追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,6 @@ class User < ApplicationRecord
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
-  validates :email, presence: true
+  validates :email, presence: true, uniqueness: true
   validates :name, presence: true, length: { maximum: 255 }
 end

--- a/db/migrate/20240508111230_add_index_to_users_email.rb
+++ b/db/migrate/20240508111230_add_index_to_users_email.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsersEmail < ActiveRecord::Migration[7.0]
+  def change
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_19_131048) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_08_111230) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,6 +73,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_19_131048) do
     t.string "salt"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
   add_foreign_key "competition_records", "competitions"


### PR DESCRIPTION

## 変更の概要

* 変更の概要
*usersテーブルにemailカラムに対するユニークインデックスを追加
* 関連するIssueやプルリクエスト
- feature #127 
- close #127

## なぜこの変更をするのか
- 現状の問題
    - 同じメールアドレスで複数アカウントが作れる状況である
    - ログインするときに、以下のSQLが発行される。
    **`users`** テーブルから **`email`** 列が 入力された値に一致するユーザーを検索し、その結果を **`id`** 列で昇順に並び替える。そして、**`LIMIT 1`** はその結果リストの最初の行だけを返すように指定している、
    - 同じアカウントで複数のemailアドレスを登録してしまった場合、
    ログインしようとしても最初のid値のアカウントしか返されず、他のアカウントは無視されてしまう

