### PR TITLE
add: パスワードリセット機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@
 !/app/assets/builds/.keep
 
 /node_modules
+
+config/settings.local.yml
+config/settings/*.local.yml
+config/environments/*.local.yml

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem 'rails-i18n', '~> 7.0.0'
 gem 'enum_help'
 
 gem 'config'
+gem 'dotenv-rails'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ gem 'sorcery'
 gem 'rails-i18n', '~> 7.0.0'
 gem 'enum_help'
 
+gem 'config'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'letter_opener_web', '~> 2.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,8 @@ GEM
     childprocess (5.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
+    config (5.4.0)
+      deep_merge (~> 1.2, >= 1.2.1)
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
@@ -101,6 +103,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     debug_inspector (1.2.0)
+    deep_merge (1.2.2)
     enum_help (0.0.19)
       activesupport (>= 3.0.0)
     erubi (1.12.0)
@@ -285,6 +288,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   capybara
+  config
   cssbundling-rails
   debug
   enum_help

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,10 @@ GEM
       reline (>= 0.3.8)
     debug_inspector (1.2.0)
     deep_merge (1.2.2)
+    dotenv (3.1.2)
+    dotenv-rails (3.1.2)
+      dotenv (= 3.1.2)
+      railties (>= 6.1)
     enum_help (0.0.19)
       activesupport (>= 3.0.0)
     erubi (1.12.0)
@@ -291,6 +295,7 @@ DEPENDENCIES
   config
   cssbundling-rails
   debug
+  dotenv-rails
   enum_help
   jbuilder
   jsbundling-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     crass (1.0.6)
@@ -123,6 +124,16 @@ GEM
       railties (>= 6.0.0)
     jwt (2.8.1)
       base64
+    launchy (3.0.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -279,6 +290,7 @@ DEPENDENCIES
   enum_help
   jbuilder
   jsbundling-rails
+  letter_opener_web (~> 2.0)
   pg (~> 1.1)
   pry-byebug
   puma (~> 5.0)

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,10 @@
+class PasswordResetsController < ApplicationController
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,10 +1,39 @@
 class PasswordResetsController < ApplicationController
+  skip_before_action :require_login
+
+  # PWリセット申請ページを表示する
+  def new; end
+
+  # ユーザーがパスワードリセットフォームにメールアドレスを入力して送信したときに実行
   def create
+    @user = User.find_by(email: params[:email]
+    # ユーザーが存在する場合(@userがnillでない)、トークンを生成し、メールを送信する
+    @user&.deliver_reset_password_instructions!
+    redirect_to login_path
   end
 
+  # パスワード再設定フォーム。受信したメールのリンクから実行される
+  # トークンでユーザーを検索し、有効期限もチェック
+  # トークンが見つかり, 有効であればそのユーザーを返す
   def edit
+    @token = params[:id]
+    @user = User.load_from_reset_password_token(@token)
+    not_authenticated if @user.blank?
+    # 認証されていないユーザーを拒否する root_pathに返す
   end
 
+  #ユーザーがパスワードリセットフォームを送信したときに実行されます。
   def update
+    @token = params[:id]
+    @user = User.load_from_reset_password_token(@token)
+
+    return not_authenticated if @user.blank?
+
+    user.password_confirmation = params[:user][:password_confirmation]
+    if @user.change_password(params[:user][:password])
+      redirect_to login_path
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -6,8 +6,7 @@ class PasswordResetsController < ApplicationController
 
   # ユーザーがパスワードリセットフォームにメールアドレスを入力して送信したときに実行
   def create
-    @user = User.find_by(email: params[:email]
-    # ユーザーが存在する場合(@userがnillでない)、トークンを生成し、メールを送信する
+    @user = User.find_by(email: params[:email])
     @user&.deliver_reset_password_instructions!
     redirect_to login_path
   end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -28,7 +28,7 @@ class PasswordResetsController < ApplicationController
 
     return not_authenticated if @user.blank?
 
-    user.password_confirmation = params[:user][:password_confirmation]
+    @user.password_confirmation = params[:user][:password_confirmation]
     if @user.change_password(params[:user][:password])
       redirect_to login_path
     else

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -1,0 +1,2 @@
+module PasswordResetsHelper
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,13 @@
+class UserMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.reset_password_email.subject
+  #
+  def reset_password_email
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -5,9 +5,10 @@ class UserMailer < ApplicationMailer
   #
   #   en.user_mailer.reset_password_email.subject
   #
-  def reset_password_email
-    @greeting = "Hi"
-
-    mail to: "to@example.org"
+  def reset_password_email(user)
+    @user = User.find(user.id)
+    @url  = edit_password_reset_url(@user.reset_password_token)
+    mail(to: user.email,
+         subject: t('PowerLifter`sLog パスワードリセット'))
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -9,6 +9,6 @@ class UserMailer < ApplicationMailer
     @user = User.find(user.id)
     @url  = edit_password_reset_url(@user.reset_password_token)
     mail(to: user.email,
-         subject: t('PowerLifter`sLog パスワードリセット'))
+        subject: t('PowerLifter`sLog パスワードリセット'))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,5 @@ class User < ApplicationRecord
 
   validates :email, presence: true, uniqueness: true
   validates :name, presence: true, length: { maximum: 255 }
+  validates :reset_password_token, uniqueness: true, allow_nil: true
 end

--- a/app/views/password_resets/create.html.erb
+++ b/app/views/password_resets/create.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#create</h1>
+<p>Find me in app/views/password_resets/create.html.erb</p>

--- a/app/views/password_resets/create.html.erb
+++ b/app/views/password_resets/create.html.erb
@@ -1,2 +1,0 @@
-<h1>PasswordResets#create</h1>
-<p>Find me in app/views/password_resets/create.html.erb</p>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#edit</h1>
+<p>Find me in app/views/password_resets/edit.html.erb</p>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -34,7 +34,7 @@
 					<%= f.submit class: 'btn btn-primary' %>
 				</div>
 			<% end %>
-      <!-- ここまでform_withを使う形に修正 -->
+    <!-- ここまでform_withを使う形に修正 -->
     </div>
   </div>
 </div>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,2 +1,40 @@
-<h1>PasswordResets#edit</h1>
-<p>Find me in app/views/password_resets/edit.html.erb</p>
+<div class="hero min-h-screen bg-base-200">
+  <div class="hero-content flex-col">
+    <div class="text-center lg:text-left">
+      <h1 class="text-5xl font-bold">会員登録</h1>
+    </div>
+    <div class="card items-center mx-auto max-w-80 min-w-80 bg-white shadow-xl p-4 text-sm">
+      <!-- ここからform_withを使う形に修正 -->
+			<%= form_with model: @user, url: password_reset_path(@token), method: :patch, html: { class: "card-body" } do |f| %>
+				<div class="form-control">
+					<div class="label p-0 flex justify-start items-center">
+						<%= f.label :email, class: 'mr-2' %>
+						<p class="text-red-500">(必須)</p>
+					</div>
+					<%= f.email_field :email, class: 'input input-bordered', placeholder:"email" %>
+					<%= render 'shared/error_messages', object: f.object, attribute: :email %>
+				</div>
+				<div class="form-control">
+					<div class="label p-0 flex justify-start items-center">
+						<%= f.label :password, class: 'mr-2' %>
+						<p class="text-red-500">(必須:3文字以上)</p>
+					</div>
+					<%= f.password_field :password, class: 'input input-bordered', placeholder:"password" %>
+					<%= render 'shared/error_messages', object: f.object, attribute: :password %>
+				</div>
+				<div class="form-control">
+					<div class="label p-0 flex justify-start items-center">
+						<%= f.label :password_confirmation, class: 'mr-2' %>
+						<p class="text-red-500">(必須:3文字以上)</p>
+					</div>
+					<%= f.password_field :password_confirmation, class: 'input input-bordered', placeholder:"password_confirmation" %>
+					<%= render 'shared/error_messages', object: f.object, attribute: :password_confirmation %>
+				</div>
+				<div class="form-control mt-6">
+					<%= f.submit class: 'btn btn-primary' %>
+				</div>
+			<% end %>
+      <!-- ここまでform_withを使う形に修正 -->
+    </div>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,24 +1,18 @@
 <div class="hero min-h-screen bg-base-200">
   <div class="hero-content flex-col lg:flex-row-reverse">
     <div class="text-center lg:text-left">
-      <h1 class="text-5xl font-bold">Login now!</h1>
+      <h1 class="text-xl font-bold">パスワードリセット申請フォーム</h1>
     </div>
     <div class="card shrink-0 w-full max-w-sm shadow-2xl bg-base-100">
       <!-- ここからform_withを使う形に修正 -->
-      <%= form_with url: login_path, html: { class: "card-body" } do |f| %>
+      <%= form_with url: password_resets_path, local: true, method: :post, html: { class: "card-body" } do |f| %>
         <div class="form-control">
           <%= f.label :email %>
           <%= f.email_field :email, class: 'input input-bordered', placeholder:"email", required: true %>
         </div>
-        <div class="form-control">
-          <%= f.label :password %>
-          <%= f.password_field :password, class: 'input input-bordered', placeholder:"password", required: true %>
-        </div>
         <div class="form-control mt-6">
-          <%= f.submit t('.login'), class: 'btn btn-primary' %>
+          <%= f.submit t('.send'), class: 'btn btn-primary' %>
         </div>
-        <!-- パスワード申請ページへのリンク -->
-        <%= link_to t('.password_forget'), new_password_reset_path, class:'text-center' %>
       <% end %>
     </div>
   </div>

--- a/app/views/password_resets/update.html.erb
+++ b/app/views/password_resets/update.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#update</h1>
+<p>Find me in app/views/password_resets/update.html.erb</p>

--- a/app/views/password_resets/update.html.erb
+++ b/app/views/password_resets/update.html.erb
@@ -1,2 +1,0 @@
-<h1>PasswordResets#update</h1>
-<p>Find me in app/views/password_resets/update.html.erb</p>

--- a/app/views/user_mailer/reset_password_email.html.erb
+++ b/app/views/user_mailer/reset_password_email.html.erb
@@ -1,0 +1,5 @@
+<h1>User#reset_password_email</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/user_mailer/reset_password_email.html.erb
+</p>

--- a/app/views/user_mailer/reset_password_email.html.erb
+++ b/app/views/user_mailer/reset_password_email.html.erb
@@ -1,5 +1,7 @@
-<h1>User#reset_password_email</h1>
+<p><%= @user.name %>様</p>
 
-<p>
-  <%= @greeting %>, find me in app/views/user_mailer/reset_password_email.html.erb
-</p>
+<p>パスワード再発行のご依頼を受け付けました。</p>
+
+<p>こちらのリンクからパスワードの再発行を行ってください。</p>
+
+<p><a href="<%= @url %>"><%= @url %></a></p>

--- a/app/views/user_mailer/reset_password_email.text.erb
+++ b/app/views/user_mailer/reset_password_email.text.erb
@@ -1,0 +1,3 @@
+User#reset_password_email
+
+<%= @greeting %>, find me in app/views/user_mailer/reset_password_email.text.erb

--- a/app/views/user_mailer/reset_password_email.text.erb
+++ b/app/views/user_mailer/reset_password_email.text.erb
@@ -1,3 +1,7 @@
-User#reset_password_email
+<%= @user.name %>様
 
-<%= @greeting %>, find me in app/views/user_mailer/reset_password_email.text.erb
+パスワード再発行のご依頼を受け付けました。
+
+こちらのリンクからパスワードの再発行を行ってください。
+
+<%= @url %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,5 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  config.action_mailer.delivery_method = :letter_opener_web
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,4 +68,6 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
   config.action_mailer.delivery_method = :letter_opener_web
+  # configのファイルで設定したhost情報を読み取りハッシュで返させる
+  config.action_mailer.default_url_options = Settings.default_url_options.to_h
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,10 +63,20 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "app_production"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = Settings.default_url_options.to_h
+  config.action_mailer.raise_delivery_errors = true
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              'smtp.gmail.com',
+    port:                 587,
+    domain:               'goodlifterlog.onrender.com',
+    user_name:            ENV['GMAIL_USERNAME'],
+    password:             ENV['GMAIL_PASSWORD'],
+    authentication:       'plain',
+    enable_starttls_auto: true
+  }
+
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -1,0 +1,68 @@
+Config.setup do |config|
+  # Name of the constant exposing loaded settings
+  config.const_name = 'Settings'
+
+  # Ability to remove elements of the array set in earlier loaded settings file. For example value: '--'.
+  #
+  # config.knockout_prefix = nil
+
+  # Overwrite an existing value when merging a `nil` value.
+  # When set to `false`, the existing value is retained after merge.
+  #
+  # config.merge_nil_values = true
+
+  # Overwrite arrays found in previously loaded settings file. When set to `false`, arrays will be merged.
+  #
+  # config.overwrite_arrays = true
+
+  # Defines current environment, affecting which settings file will be loaded.
+  # Default: `Rails.env`
+  #
+  # config.environment = ENV.fetch('ENVIRONMENT', :development)
+
+  # Load environment variables from the `ENV` object and override any settings defined in files.
+  #
+  # config.use_env = false
+
+  # Define ENV variable prefix deciding which variables to load into config.
+  #
+  # Reading variables from ENV is case-sensitive. If you define lowercase value below, ensure your ENV variables are
+  # prefixed in the same way.
+  #
+  # When not set it defaults to `config.const_name`.
+  #
+  config.env_prefix = 'SETTINGS'
+
+  # What string to use as level separator for settings loaded from ENV variables. Default value of '.' works well
+  # with Heroku, but you might want to change it for example for '__' to easy override settings from command line, where
+  # using dots in variable names might not be allowed (eg. Bash).
+  #
+  # config.env_separator = '.'
+
+  # Ability to process variables names:
+  #   * nil  - no change
+  #   * :downcase - convert to lower case
+  #
+  # config.env_converter = :downcase
+
+  # Parse numeric values as integers instead of strings.
+  #
+  # config.env_parse_values = true
+
+  # Validate presence and type of specific config values. Check https://github.com/dry-rb/dry-validation for details.
+  #
+  # config.schema do
+  #   required(:name).filled
+  #   required(:age).maybe(:int?)
+  #   required(:email).filled(format?: EMAIL_REGEX)
+  # end
+
+  # Evaluate ERB in YAML config files at load time.
+  #
+  # config.evaluate_erb_in_yaml = true
+
+  # Name of directory and file to store config keys
+  #
+  # config.file_name = 'settings'
+  # config.dir_name = 'settings'
+end

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = []
+Rails.application.config.sorcery.submodules = [:reset_password]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -243,6 +243,7 @@ Rails.application.config.sorcery.configure do |config|
   # config.battlenet.scope = "openid"
   # --- user config ---
   config.user_config do |user|
+    user.reset_password_mailer = UserMailer
     # -- core --
     # Specify username attributes, for example: [:username, :email].
     # Default: `[:email]`

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -13,6 +13,12 @@ ja:
       login: ログイン
       to_register_page: 会員登録ページへ
       password_forget: パスワードをお忘れの方はこちら
+  password_resets:
+    new:
+      title: パスワードリセット申請
+      send: 送信
+    edit:
+      title: パスワードリセット
   users:
     new:
       title: ユーザー登録

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,9 @@
 Rails.application.routes.draw do
-  get 'password_resets/create'
-  get 'password_resets/edit'
-  get 'password_resets/update'
   root "tops#index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   resources :users, only: [:create, :new, :edit, :update]
   resource :profile, only: [:show, :edit, :update]
+  resources :password_resets, only: [:create, :edit, :update, :new]
   resources :competitions do
     resource :competition_record, only: [:create, :new, :edit, :update, :destroy]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get 'password_resets/create'
+  get 'password_resets/edit'
+  get 'password_resets/update'
   root "tops#index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   resources :users, only: [:create, :new, :edit, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,6 @@ Rails.application.routes.draw do
   get 'login', to: 'user_sessions#new', :as => :login
   post 'login', to: "user_sessions#create"
   delete 'logout', to: 'user_sessions#destroy', :as => :logout
+
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,2 @@
+default_url_options:
+  host: 'localhost:3000'

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,0 +1,2 @@
+default_url_options:
+  host: 'goodlifterlog.onrender.com'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,2 @@
+default_url_options:
+  host: 'localhost:3000'

--- a/db/migrate/20240508124250_sorcery_reset_password.rb
+++ b/db/migrate/20240508124250_sorcery_reset_password.rb
@@ -1,0 +1,10 @@
+class SorceryResetPassword < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :reset_password_token, :string, default: nil
+    add_column :users, :reset_password_token_expires_at, :datetime, default: nil
+    add_column :users, :reset_password_email_sent_at, :datetime, default: nil
+    add_column :users, :access_count_to_reset_password_page, :integer, default: 0
+
+    add_index :users, :reset_password_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_08_111230) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_08_124250) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,7 +73,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_08_111230) do
     t.string "salt"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_token_expires_at"
+    t.datetime "reset_password_email_sent_at"
+    t.integer "access_count_to_reset_password_page", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
   add_foreign_key "competition_records", "competitions"

--- a/test/controllers/password_resets_controller_test.rb
+++ b/test/controllers/password_resets_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
+  test "should get create" do
+    get password_resets_create_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get password_resets_edit_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get password_resets_update_url
+    assert_response :success
+  end
+end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,9 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/reset_password_email
+  def reset_password_email
+    UserMailer.reset_password_email
+  end
+
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class UserMailerTest < ActionMailer::TestCase
+  test "reset_password_email" do
+    mail = UserMailer.reset_password_email
+    assert_equal "Reset password email", mail.subject
+    assert_equal ["to@example.org"], mail.to
+    assert_equal ["from@example.com"], mail.from
+    assert_match "Hi", mail.body.encoded
+  end
+
+end


### PR DESCRIPTION
## 変更の概要

* 変更の概要
パスワードリセット機能の追加をしました

* 関連するIssueやプルリクエスト
- feature #21 
- close #21 

## やったこと

* [x] 開発環境は、gem letter_opener_webでメール送信とパスワードリセットができることを確認した
* [x] パスワードリセット機能はsorceryのモジュールを使用
* [x] メールのビューファイルで生成させるURLのホスト情報はgem configを使用して、環境ごとに変わるようにした
* [x] 本番環境のメール送信はGmailを使用

