### PR TITLE
add: 試技結果のステップ入力化

### DIFF
--- a/app/controllers/record/bench_presses_controller.rb
+++ b/app/controllers/record/bench_presses_controller.rb
@@ -1,10 +1,12 @@
 class Record::BenchPressesController < ApplicationController
   def new
     @bench_press = Record::BenchPress.new
+    @competition = current_user.competitions.find(params[:competition_id])
   end
 
   def create
     @bench_press = Record::BenchPress.new(bench_press_params)
+    @competition = current_user.competitions.find(params[:competition_id])
     if @bench_press.valid? # 手動でバリデーションの検証をする
       session[:record].merge!({
         benchpress_first_attempt: @bench_press.benchpress_first_attempt,

--- a/app/controllers/record/bench_presses_controller.rb
+++ b/app/controllers/record/bench_presses_controller.rb
@@ -1,7 +1,31 @@
 class Record::BenchPressesController < ApplicationController
   def new
+    @bench_press = Record::BenchPress.new
   end
 
   def create
+    @bench_press = Record::BenchPress.new(bench_press_params)
+    if @bench_press.valid? # 手動でバリデーションの検証をする
+      session[:record].merge!({
+        benchpress_first_attempt: @bench_press.benchpress_first_attempt,
+        benchpress_second_attempt: @bench_press.benchpress_second_attempt,
+        benchpress_third_attempt: @bench_press.benchpress_third_attempt,
+        benchpress_first_attempt_result: @bench_press.benchpress_first_attempt_result,
+        benchpress_second_attempt_result: @bench_press.benchpress_second_attempt_result,
+        benchpress_third_attempt_result: @bench_press.benchpress_third_attempt_result
+      })
+      redirect_to  new_competition_deadlift_path # 次のステップへ遷移
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def bench_press_params
+    params.require(:record_bench_press).permit(
+    :benchpress_first_attempt, :benchpress_first_attempt_result,
+    :benchpress_second_attempt, :benchpress_second_attempt_result,
+    :benchpress_third_attempt, :benchpress_third_attempt_result)
   end
 end

--- a/app/controllers/record/bench_presses_controller.rb
+++ b/app/controllers/record/bench_presses_controller.rb
@@ -1,0 +1,7 @@
+class Record::BenchPressesController < ApplicationController
+  def new
+  end
+
+  def create
+  end
+end

--- a/app/controllers/record/bench_presses_controller.rb
+++ b/app/controllers/record/bench_presses_controller.rb
@@ -1,4 +1,5 @@
 class Record::BenchPressesController < ApplicationController
+  skip_before_action :set_bottom_navi, only: %i[ new edit ]
   def new
     @bench_press = Record::BenchPress.new
     @competition = current_user.competitions.find(params[:competition_id])

--- a/app/controllers/record/comments_controller.rb
+++ b/app/controllers/record/comments_controller.rb
@@ -1,34 +1,27 @@
 class Record::CommentsController < ApplicationController
   def new
     @comment = Record::Comment.new
+    @competition = current_user.competitions.find(params[:competition_id])
   end
 
   def create
-    def create
-      @comment = Record::Comment.new(comment_params)
-      if @comment.valid? # 手動でバリデーションの検証をする
-        # @commentを、sessionに保存
-        session[:record][:comment] = @comment.comment
-        # セッションからデータを、キーと値のペアで取り出す
-        @competition_record_params = session[:record].slice(
-          :competition_id, :weight,
-          :squat_first_attempt, :squat_second_attempt, :squat_third_attempt,
-          :squat_first_attempt_result, :squat_second_attempt_result, :squat_third_attempt_result,
-          :benchpress_first_attempt, :benchpress_second_attempt, :benchpress_third_attempt,
-          :benchpress_first_attempt_result, :benchpress_second_attempt_result, :benchpress_third_attempt_result,
-          :deadlift_first_attempt, :deadlift_second_attempt, :deadlift_third_attempt,
-          :deadlift_first_attempt_result, :deadlift_second_attempt_result, :deadlift_third_attempt_result,
-          :comment
-        )
-        # レコードを保存する
-        CompetitionRecord.create!(competition_record_params)
-        # セッションをクリアにする
-        session.delete(:record)
-        # 大会結果詳細ページへ遷移
-        redirect_to competition_path(@competition_record_params)
-      else
-        render :new, status: :unprocessable_entity
-      end
+    @comment = Record::Comment.new(comment_params)
+    @competition = current_user.competitions.find(params[:competition_id])
+    if @comment.valid? # 手動でバリデーションの検証をする
+      # @commentを、sessionに保存
+      session[:record].merge!({
+        comment: @comment.comment
+      })
+      # セッションからデータを、キーと値のペアで取り出す
+      @competition_record_params = session[:record]
+      # レコードを保存する
+      CompetitionRecord.create!(@competition_record_params)
+      # セッションをクリアにする
+      session.delete(:record)
+      # 大会結果詳細ページへ遷移
+      redirect_to competition_path(@competition)
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/record/comments_controller.rb
+++ b/app/controllers/record/comments_controller.rb
@@ -1,7 +1,40 @@
 class Record::CommentsController < ApplicationController
   def new
+    @comment = Record::Comment.new
   end
 
   def create
+    def create
+      @comment = Record::Comment.new(comment_params)
+      if @comment.valid? # 手動でバリデーションの検証をする
+        # @commentを、sessionに保存
+        session[:record][:comment] = @comment.comment
+        # セッションからデータを、キーと値のペアで取り出す
+        @competition_record_params = session[:record].slice(
+          :competition_id, :weight,
+          :squat_first_attempt, :squat_second_attempt, :squat_third_attempt,
+          :squat_first_attempt_result, :squat_second_attempt_result, :squat_third_attempt_result,
+          :benchpress_first_attempt, :benchpress_second_attempt, :benchpress_third_attempt,
+          :benchpress_first_attempt_result, :benchpress_second_attempt_result, :benchpress_third_attempt_result,
+          :deadlift_first_attempt, :deadlift_second_attempt, :deadlift_third_attempt,
+          :deadlift_first_attempt_result, :deadlift_second_attempt_result, :deadlift_third_attempt_result,
+          :comment
+        )
+        # レコードを保存する
+        CompetitionRecord.create!(competition_record_params)
+        # セッションをクリアにする
+        session.delete(:record)
+        # 大会結果詳細ページへ遷移
+        redirect_to competition_path(@competition_record_params)
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:record_comment).permit(:comment)
   end
 end

--- a/app/controllers/record/comments_controller.rb
+++ b/app/controllers/record/comments_controller.rb
@@ -1,4 +1,6 @@
 class Record::CommentsController < ApplicationController
+  skip_before_action :set_bottom_navi, only: %i[ new edit ]
+
   def new
     @comment = Record::Comment.new
     @competition = current_user.competitions.find(params[:competition_id])

--- a/app/controllers/record/comments_controller.rb
+++ b/app/controllers/record/comments_controller.rb
@@ -1,0 +1,7 @@
+class Record::CommentsController < ApplicationController
+  def new
+  end
+
+  def create
+  end
+end

--- a/app/controllers/record/deadlifts_controller.rb
+++ b/app/controllers/record/deadlifts_controller.rb
@@ -1,11 +1,13 @@
 class Record::DeadliftsController < ApplicationController
   def new
     @dedlift = Record::Deadlift.new
+    @competition = current_user.competitions.find(params[:competition_id])
   end
 
   def create
-    @dedlift = Record::Deadlift.new(dedlift_params)
-    if @dedlift.valid? # 手動でバリデーションの検証をする
+    @deadlift = Record::Deadlift.new(deadlift_params)
+    @competition = current_user.competitions.find(params[:competition_id])
+    if @deadlift.valid? # 手動でバリデーションの検証をする
       session[:record].merge!({
         deadlift_first_attempt: @deadlift.deadlift_first_attempt,
         deadlift_second_attempt: @deadlift.deadlift_second_attempt,

--- a/app/controllers/record/deadlifts_controller.rb
+++ b/app/controllers/record/deadlifts_controller.rb
@@ -1,0 +1,7 @@
+class Record::DeadliftsController < ApplicationController
+  def new
+  end
+
+  def create
+  end
+end

--- a/app/controllers/record/deadlifts_controller.rb
+++ b/app/controllers/record/deadlifts_controller.rb
@@ -1,6 +1,8 @@
 class Record::DeadliftsController < ApplicationController
+  skip_before_action :set_bottom_navi, only: %i[ new edit ]
+
   def new
-    @dedlift = Record::Deadlift.new
+    @deadlift = Record::Deadlift.new
     @competition = current_user.competitions.find(params[:competition_id])
   end
 

--- a/app/controllers/record/deadlifts_controller.rb
+++ b/app/controllers/record/deadlifts_controller.rb
@@ -1,7 +1,31 @@
 class Record::DeadliftsController < ApplicationController
   def new
+    @dedlift = Record::Deadlift.new
   end
 
   def create
+    @dedlift = Record::Deadlift.new(dedlift_params)
+    if @dedlift.valid? # 手動でバリデーションの検証をする
+      session[:record].merge!({
+        deadlift_first_attempt: @deadlift.deadlift_first_attempt,
+        deadlift_second_attempt: @deadlift.deadlift_second_attempt,
+        deadlift_third_attempt: @deadlift.deadlift_third_attempt,
+        deadlift_first_attempt_result: @deadlift.deadlift_first_attempt_result,
+        deadlift_second_attempt_result: @deadlift.deadlift_second_attempt_result,
+        deadlift_third_attempt_result: @deadlift.deadlift_third_attempt_result
+      })
+      redirect_to new_competition_comment_path # 次のステップへ遷移
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def deadlift_params
+    params.require(:record_deadlift).permit(
+    :deadlift_first_attempt, :deadlift_first_attempt_result,
+    :deadlift_second_attempt, :deadlift_second_attempt_result,
+    :deadlift_third_attempt, :deadlift_third_attempt_result)
   end
 end

--- a/app/controllers/record/squats_controller.rb
+++ b/app/controllers/record/squats_controller.rb
@@ -1,7 +1,31 @@
 class Record::SquatsController < ApplicationController
   def new
+    @squat = Record::Squat.new
   end
 
   def create
+    @squat = Record::Squat.new(squat_params)
+    if @squat.valid? # 手動でバリデーションの検証をする
+      session[:record].merge!({
+        squat_first_attempt: @squat.squat_first_attempt,
+        squat_second_attempt: @squat.squat_second_attempt,
+        squat_third_attempt: @squat.squat_third_attempt,
+        squat_first_attempt_result: @squat.squat_first_attempt_result,
+        squat_second_attempt_result: @squat.squat_second_attempt_result,
+        squat_third_attempt_result: @squat.squat_third_attempt_result
+      })
+      redirect_to new_competition_bench_presse_path # 次のステップへ遷移
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def squat_params
+    params.require(:record_squat).permit(
+    :squat_first_attempt, :squat_first_attempt_result,
+    :squat_second_attempt, :squat_second_attempt_result,
+    :squat_third_attempt, :squat_third_attempt_result)
   end
 end

--- a/app/controllers/record/squats_controller.rb
+++ b/app/controllers/record/squats_controller.rb
@@ -1,4 +1,6 @@
 class Record::SquatsController < ApplicationController
+skip_before_action :set_bottom_navi, only: %i[ new edit ]
+
   def new
     @squat = Record::Squat.new
     @competition = current_user.competitions.find(params[:competition_id])

--- a/app/controllers/record/squats_controller.rb
+++ b/app/controllers/record/squats_controller.rb
@@ -1,0 +1,7 @@
+class Record::SquatsController < ApplicationController
+  def new
+  end
+
+  def create
+  end
+end

--- a/app/controllers/record/squats_controller.rb
+++ b/app/controllers/record/squats_controller.rb
@@ -1,10 +1,12 @@
 class Record::SquatsController < ApplicationController
   def new
     @squat = Record::Squat.new
+    @competition = current_user.competitions.find(params[:competition_id])
   end
 
   def create
     @squat = Record::Squat.new(squat_params)
+    @competition = current_user.competitions.find(params[:competition_id])
     if @squat.valid? # 手動でバリデーションの検証をする
       session[:record].merge!({
         squat_first_attempt: @squat.squat_first_attempt,

--- a/app/controllers/record/weigh_ins_controller.rb
+++ b/app/controllers/record/weigh_ins_controller.rb
@@ -1,4 +1,6 @@
 class Record::WeighInsController < ApplicationController
+  skip_before_action :set_bottom_navi, only: %i[ new edit ]
+
   def new
     @weigh_in = Record::WeighIn.new
     @competition = current_user.competitions.find(params[:competition_id])

--- a/app/controllers/record/weigh_ins_controller.rb
+++ b/app/controllers/record/weigh_ins_controller.rb
@@ -1,0 +1,21 @@
+class Record::WeighInsController < ApplicationController
+  def new
+    @weigh_in = weigh_in.new
+  end
+
+  def create
+    @weigh_in = WeighIn.new(weigh_in_params)
+    if @weigh_in.valid? # 手動でバリデーションの検証をする
+      session[:weigh_in] = @weigh_in.weight # セッションに一時保存
+      redirect_to new_record_squat_path # 次のステップへ遷移
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def weigh_in_params
+    params.require(:record_weigh_in).permit(:weight)
+  end
+end

--- a/app/controllers/record/weigh_ins_controller.rb
+++ b/app/controllers/record/weigh_ins_controller.rb
@@ -1,10 +1,12 @@
 class Record::WeighInsController < ApplicationController
   def new
     @weigh_in = Record::WeighIn.new
+    @competition = current_user.competitions.find(params[:competition_id])
   end
 
   def create
     @weigh_in = Record::WeighIn.new(weigh_in_params)
+    @competition = current_user.competitions.find(params[:competition_id])
     if @weigh_in.valid? # 手動でバリデーションの検証をする
       session[:record] = {
         competition_id: @weigh_in.competition_id,
@@ -19,6 +21,6 @@ class Record::WeighInsController < ApplicationController
   private
 
   def weigh_in_params
-    params.require(:record_weigh_in).permit(:weight, :competition_id)
+    params.require(:record_weigh_in).permit(:weight).merge(competition_id: params[:competition_id])
   end
 end

--- a/app/controllers/record/weigh_ins_controller.rb
+++ b/app/controllers/record/weigh_ins_controller.rb
@@ -7,9 +7,9 @@ class Record::WeighInsController < ApplicationController
     @weigh_in = WeighIn.new(weigh_in_params)
     if @weigh_in.valid? # 手動でバリデーションの検証をする
       session[:weigh_in] = @weigh_in.weight # セッションに一時保存
-      redirect_to new_record_squat_path # 次のステップへ遷移
+      redirect_to new_competition_squat_path # 次のステップへ遷移
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/record/weigh_ins_controller.rb
+++ b/app/controllers/record/weigh_ins_controller.rb
@@ -1,12 +1,15 @@
 class Record::WeighInsController < ApplicationController
   def new
-    @weigh_in = weigh_in.new
+    @weigh_in = Record::WeighIn.new
   end
 
   def create
-    @weigh_in = WeighIn.new(weigh_in_params)
+    @weigh_in = Record::WeighIn.new(weigh_in_params)
     if @weigh_in.valid? # 手動でバリデーションの検証をする
-      session[:weigh_in] = @weigh_in.weight # セッションに一時保存
+      session[:record] = {
+        competition_id: @weigh_in.competition_id,
+        weight: @weigh_in.weight
+      }
       redirect_to new_competition_squat_path # 次のステップへ遷移
     else
       render :new, status: :unprocessable_entity
@@ -16,6 +19,6 @@ class Record::WeighInsController < ApplicationController
   private
 
   def weigh_in_params
-    params.require(:record_weigh_in).permit(:weight)
+    params.require(:record_weigh_in).permit(:weight, :competition_id)
   end
 end

--- a/app/helpers/record/bench_presses_helper.rb
+++ b/app/helpers/record/bench_presses_helper.rb
@@ -1,0 +1,2 @@
+module Record::BenchPressesHelper
+end

--- a/app/helpers/record/comments_helper.rb
+++ b/app/helpers/record/comments_helper.rb
@@ -1,0 +1,2 @@
+module Record::CommentsHelper
+end

--- a/app/helpers/record/deadlifts_helper.rb
+++ b/app/helpers/record/deadlifts_helper.rb
@@ -1,0 +1,2 @@
+module Record::DeadliftsHelper
+end

--- a/app/helpers/record/squats_helper.rb
+++ b/app/helpers/record/squats_helper.rb
@@ -1,0 +1,2 @@
+module Record::SquatsHelper
+end

--- a/app/helpers/record/weigh_ins_helper.rb
+++ b/app/helpers/record/weigh_ins_helper.rb
@@ -1,0 +1,2 @@
+module Record::WeighInsHelper
+end

--- a/app/models/record/bench_press.rb
+++ b/app/models/record/bench_press.rb
@@ -1,0 +1,46 @@
+class Record::BenchPress
+	include ActiveModel::Model
+	attr_accessor :benchpress_first_attempt,
+								:benchpress_second_attempt,
+								:benchpress_third_attempt,
+								:benchpress_first_attempt_result,
+								:benchpress_second_attempt_result,
+								:benchpress_third_attempt_result
+	# ベンチプレス各試技のバリテーション設定
+	with_options numericality: true, allow_nil: true do
+		validates :benchpress_first_attempt
+		validates :benchpress_second_attempt
+		validates :benchpress_third_attempt
+	end
+	# ベンチプレス試技判定結果のバリテーション設定
+	# 空は禁止
+	with_options presence: true do
+		validates :benchpress_first_attempt_result
+		validates :benchpress_second_attempt_result
+		validates :benchpress_third_attempt_result
+	end
+	# 重量の入力があったら成功か、失敗か選択させる
+	validate :benchpress_first_attempt_is_not_be_not_attempted
+  validate :benchpress_second_attempt_is_not_be_not_attempted
+  validate :benchpress_third_attempt_is_not_be_not_attempted
+
+	private
+	# カスタムバリデータ　ベンチプレス判定結果
+  def benchpress_first_attempt_is_not_be_not_attempted
+    if benchpress_first_attempt.present? && benchpress_first_attempt >= 0 && benchpress_first_attempt_result == "not_attempted"
+      errors.add(:benchpress_first_attempt_result, "は成功か失敗かを選んでください")
+    end
+  end
+
+  def benchpress_second_attempt_is_not_be_not_attempted
+    if benchpress_second_attempt.present? && benchpress_second_attempt >= 0 && benchpress_second_attempt_result == "not_attempted"
+      errors.add(:benchpress_second_attempt_result, "は成功か失敗かを選んでください")
+    end
+  end
+
+  def benchpress_third_attempt_is_not_be_not_attempted
+    if benchpress_third_attempt.present? && benchpress_third_attempt >= 0 && benchpress_third_attempt_result == "not_attempted"
+      errors.add(:benchpress_third_attempt_result, "は成功か失敗かを選んでください")
+    end
+  end
+end

--- a/app/models/record/bench_press.rb
+++ b/app/models/record/bench_press.rb
@@ -1,46 +1,76 @@
 class Record::BenchPress
 	include ActiveModel::Model
+	include ActiveModel::Validations
+
 	attr_accessor :benchpress_first_attempt,
 								:benchpress_second_attempt,
 								:benchpress_third_attempt,
 								:benchpress_first_attempt_result,
 								:benchpress_second_attempt_result,
 								:benchpress_third_attempt_result
-	# ベンチプレス各試技のバリテーション設定
-	with_options numericality: true, allow_nil: true do
-		validates :benchpress_first_attempt
-		validates :benchpress_second_attempt
-		validates :benchpress_third_attempt
-	end
-	# ベンチプレス試技判定結果のバリテーション設定
-	# 空は禁止
+
+	# 初期化メソッド
+	def initialize(attributes = {})
+    super
+		@benchpress_first_attempt ||= nil
+    @benchpress_second_attempt ||= nil
+    @benchpress_third_attempt ||= nil
+    @benchpress_first_attempt_result ||= "not_attempted"
+    @benchpress_second_attempt_result ||= "not_attempted"
+    @benchpress_third_attempt_result ||= "not_attempted"
+  end
+
+	# スクワット各試技のバリテーション設定
+	validates :benchpress_first_attempt, numericality: { allow_nil: true }, if: :should_validate_benchpress_first_attempt_numericality?
+	validates :benchpress_second_attempt, numericality: { allow_nil: true }, if: :should_validate_benchpress_second_attempt_numericality?
+	validates :benchpress_third_attempt, numericality: { allow_nil: true }, if: :should_validate_benchpress_third_attempt_numericality?
+
+
+	# スクワット試技判定結果のバリテーション設定
+		# 空は禁止
 	with_options presence: true do
 		validates :benchpress_first_attempt_result
 		validates :benchpress_second_attempt_result
 		validates :benchpress_third_attempt_result
 	end
+
 	# 重量の入力があったら成功か、失敗か選択させる
-	validate :benchpress_first_attempt_is_not_be_not_attempted
-  validate :benchpress_second_attempt_is_not_be_not_attempted
-  validate :benchpress_third_attempt_is_not_be_not_attempted
+	validate :benchpress_first_attempt_is_not_be_not_attempted, unless: :should_validate_benchpress_first_attempt_numericality?
+	validate :benchpress_second_attempt_is_not_be_not_attempted, unless: :should_validate_benchpress_second_attempt_numericality?
+	validate :benchpress_third_attempt_is_not_be_not_attempted, unless: :should_validate_benchpress_third_attempt_numericality?
 
 	private
-	# カスタムバリデータ　ベンチプレス判定結果
-  def benchpress_first_attempt_is_not_be_not_attempted
-    if benchpress_first_attempt.present? && benchpress_first_attempt >= 0 && benchpress_first_attempt_result == "not_attempted"
-      errors.add(:benchpress_first_attempt_result, "は成功か失敗かを選んでください")
-    end
-  end
+	# 重量の入力フォームに文字列が入力されていないか？
+	# 第一試技
+	def should_validate_benchpress_first_attempt_numericality?
+		benchpress_first_attempt.present? && Float(benchpress_first_attempt, exception: false).nil?
+	end
+	# 第二試技
+	def should_validate_benchpress_second_attempt_numericality?
+		benchpress_second_attempt.present? && Float(benchpress_second_attempt, exception: false).nil?
+	end
+	# 第三試技
+	def should_validate_benchpress_third_attempt_numericality?
+		benchpress_third_attempt.present? && Float(benchpress_third_attempt, exception: false).nil?
+	end
 
-  def benchpress_second_attempt_is_not_be_not_attempted
-    if benchpress_second_attempt.present? && benchpress_second_attempt >= 0 && benchpress_second_attempt_result == "not_attempted"
-      errors.add(:benchpress_second_attempt_result, "は成功か失敗かを選んでください")
-    end
-  end
-
-  def benchpress_third_attempt_is_not_be_not_attempted
-    if benchpress_third_attempt.present? && benchpress_third_attempt >= 0 && benchpress_third_attempt_result == "not_attempted"
-      errors.add(:benchpress_third_attempt_result, "は成功か失敗かを選んでください")
-    end
-  end
+	# カスタムバリデータ　スクワット判定結果
+	# 第一試技
+	def benchpress_first_attempt_is_not_be_not_attempted
+		if benchpress_first_attempt.present? && Float(benchpress_first_attempt, exception: false) >= 0 && benchpress_first_attempt_result == "not_attempted"
+			errors.add(:benchpress_first_attempt_result, "は成功か失敗かを選んでください")
+		end
+	end
+	# 第一試技
+	def benchpress_second_attempt_is_not_be_not_attempted
+		if benchpress_second_attempt.present? && Float(benchpress_second_attempt, exception: false) >= 0 && benchpress_second_attempt_result == "not_attempted"
+			errors.add(:benchpress_second_attempt_result, "は成功か失敗かを選んでください")
+		end
+	end
+	# 第二試技
+	def benchpress_third_attempt_is_not_be_not_attempted
+		if benchpress_third_attempt.present? && Float(benchpress_third_attempt, exception: false) >= 0 && benchpress_third_attempt_result == "not_attempted"
+			errors.add(:benchpress_third_attempt_result, "は成功か失敗かを選んでください")
+		end
+	end
 end

--- a/app/models/record/comment.rb
+++ b/app/models/record/comment.rb
@@ -1,4 +1,5 @@
 class Record::Comment
 	include ActiveModel::Model
-	attr_accessor :comment
+	include ActiveModel::Attributes
+	attribute :comment, :string, default: nil
 end

--- a/app/models/record/comment.rb
+++ b/app/models/record/comment.rb
@@ -1,0 +1,4 @@
+class Record::Comment
+	include ActiveModel::Model
+	attr_accessor :comment
+end

--- a/app/models/record/deadlift.rb
+++ b/app/models/record/deadlift.rb
@@ -1,47 +1,76 @@
 class Record::Deadlift
-  include ActiveModel::Model
+	include ActiveModel::Model
+	include ActiveModel::Validations
+
 	attr_accessor :deadlift_first_attempt,
 								:deadlift_second_attempt,
 								:deadlift_third_attempt,
 								:deadlift_first_attempt_result,
 								:deadlift_second_attempt_result,
 								:deadlift_third_attempt_result
+
+	# 初期化メソッド
+	def initialize(attributes = {})
+    super
+		@deadlift_first_attempt ||= nil
+    @deadlift_second_attempt ||= nil
+    @deadlift_third_attempt ||= nil
+    @deadlift_first_attempt_result ||= "not_attempted"
+    @deadlift_second_attempt_result ||= "not_attempted"
+    @deadlift_third_attempt_result ||= "not_attempted"
+  end
+
 	# スクワット各試技のバリテーション設定
-	with_options numericality: true, allow_nil: true do
-		validates :deadlift_first_attempt
-		validates :deadlift_second_attempt
-		validates :deadlift_third_attempt
-	end
+	validates :deadlift_first_attempt, numericality: { allow_nil: true }, if: :should_validate_deadlift_first_attempt_numericality?
+	validates :deadlift_second_attempt, numericality: { allow_nil: true }, if: :should_validate_deadlift_second_attempt_numericality?
+	validates :deadlift_third_attempt, numericality: { allow_nil: true }, if: :should_validate_deadlift_third_attempt_numericality?
+
+
 	# スクワット試技判定結果のバリテーション設定
-	# 空は禁止
+		# 空は禁止
 	with_options presence: true do
 		validates :deadlift_first_attempt_result
 		validates :deadlift_second_attempt_result
 		validates :deadlift_third_attempt_result
 	end
+
 	# 重量の入力があったら成功か、失敗か選択させる
-	validate :deadlift_first_attempt_is_not_be_not_attempted
-	validate :deadlift_second_attempt_is_not_be_not_attempted
-	validate :deadlift_third_attempt_is_not_be_not_attempted
+	validate :deadlift_first_attempt_is_not_be_not_attempted, unless: :should_validate_deadlift_first_attempt_numericality?
+	validate :deadlift_second_attempt_is_not_be_not_attempted, unless: :should_validate_deadlift_second_attempt_numericality?
+	validate :deadlift_third_attempt_is_not_be_not_attempted, unless: :should_validate_deadlift_third_attempt_numericality?
 
 	private
+	# 重量の入力フォームに文字列が入力されていないか？
+	# 第一試技
+	def should_validate_deadlift_first_attempt_numericality?
+		deadlift_first_attempt.present? && Float(deadlift_first_attempt, exception: false).nil?
+	end
+	# 第二試技
+	def should_validate_deadlift_second_attempt_numericality?
+		deadlift_second_attempt.present? && Float(deadlift_second_attempt, exception: false).nil?
+	end
+	# 第三試技
+	def should_validate_deadlift_third_attempt_numericality?
+		deadlift_third_attempt.present? && Float(deadlift_third_attempt, exception: false).nil?
+	end
 
-  # カスタムバリデータ　デッドリフト判定結果
-  def deadlift_first_attempt_is_not_be_not_attempted
-    if deadlift_first_attempt.present? && deadlift_first_attempt >= 0 && deadlift_first_attempt_result == "not_attempted"
-      errors.add(:deadlift_first_attempt_result, "は成功か失敗かを選んでください")
-    end
-  end
-
-  def deadlift_second_attempt_is_not_be_not_attempted
-    if deadlift_second_attempt.present? && deadlift_second_attempt >= 0 && deadlift_second_attempt_result == "not_attempted"
-      errors.add(:deadlift_second_attempt_result, "は成功か失敗かを選んでください")
-    end
-  end
-
-  def deadlift_third_attempt_is_not_be_not_attempted
-    if deadlift_third_attempt.present? && deadlift_third_attempt >= 0 && deadlift_third_attempt_result == "not_attempted"
-      errors.add(:deadlift_third_attempt_result, "は成功か失敗かを選んでください")
-    end
-  end
+	# カスタムバリデータ　スクワット判定結果
+	# 第一試技
+	def deadlift_first_attempt_is_not_be_not_attempted
+		if deadlift_first_attempt.present? && Float(deadlift_first_attempt, exception: false) >= 0 && deadlift_first_attempt_result == "not_attempted"
+			errors.add(:deadlift_first_attempt_result, "は成功か失敗かを選んでください")
+		end
+	end
+	# 第一試技
+	def deadlift_second_attempt_is_not_be_not_attempted
+		if deadlift_second_attempt.present? && Float(deadlift_second_attempt, exception: false) >= 0 && deadlift_second_attempt_result == "not_attempted"
+			errors.add(:deadlift_second_attempt_result, "は成功か失敗かを選んでください")
+		end
+	end
+	# 第二試技
+	def deadlift_third_attempt_is_not_be_not_attempted
+		if deadlift_third_attempt.present? && Float(deadlift_third_attempt, exception: false) >= 0 && deadlift_third_attempt_result == "not_attempted"
+			errors.add(:deadlift_third_attempt_result, "は成功か失敗かを選んでください")
+		end
+	end
 end

--- a/app/models/record/deadlift.rb
+++ b/app/models/record/deadlift.rb
@@ -1,0 +1,47 @@
+class Record::Deadlift
+  include ActiveModel::Model
+	attr_accessor :deadlift_first_attempt,
+								:deadlift_second_attempt,
+								:deadlift_third_attempt,
+								:deadlift_first_attempt_result,
+								:deadlift_second_attempt_result,
+								:deadlift_third_attempt_result
+	# スクワット各試技のバリテーション設定
+	with_options numericality: true, allow_nil: true do
+		validates :deadlift_first_attempt
+		validates :deadlift_second_attempt
+		validates :deadlift_third_attempt
+	end
+	# スクワット試技判定結果のバリテーション設定
+	# 空は禁止
+	with_options presence: true do
+		validates :deadlift_first_attempt_result
+		validates :deadlift_second_attempt_result
+		validates :deadlift_third_attempt_result
+	end
+	# 重量の入力があったら成功か、失敗か選択させる
+	validate :deadlift_first_attempt_is_not_be_not_attempted
+	validate :deadlift_second_attempt_is_not_be_not_attempted
+	validate :deadlift_third_attempt_is_not_be_not_attempted
+
+	private
+
+  # カスタムバリデータ　デッドリフト判定結果
+  def deadlift_first_attempt_is_not_be_not_attempted
+    if deadlift_first_attempt.present? && deadlift_first_attempt >= 0 && deadlift_first_attempt_result == "not_attempted"
+      errors.add(:deadlift_first_attempt_result, "は成功か失敗かを選んでください")
+    end
+  end
+
+  def deadlift_second_attempt_is_not_be_not_attempted
+    if deadlift_second_attempt.present? && deadlift_second_attempt >= 0 && deadlift_second_attempt_result == "not_attempted"
+      errors.add(:deadlift_second_attempt_result, "は成功か失敗かを選んでください")
+    end
+  end
+
+  def deadlift_third_attempt_is_not_be_not_attempted
+    if deadlift_third_attempt.present? && deadlift_third_attempt >= 0 && deadlift_third_attempt_result == "not_attempted"
+      errors.add(:deadlift_third_attempt_result, "は成功か失敗かを選んでください")
+    end
+  end
+end

--- a/app/models/record/squat.rb
+++ b/app/models/record/squat.rb
@@ -1,17 +1,31 @@
 class Record::Squat
 	include ActiveModel::Model
+	include ActiveModel::Validations
+
 	attr_accessor :squat_first_attempt,
 								:squat_second_attempt,
 								:squat_third_attempt,
 								:squat_first_attempt_result,
 								:squat_second_attempt_result,
 								:squat_third_attempt_result
+
+	# 初期化メソッド
+	def initialize(attributes = {})
+    super
+		@squat_first_attempt ||= nil
+    @squat_second_attempt ||= nil
+    @squat_third_attempt ||= nil
+    @squat_first_attempt_result ||= "not_attempted"
+    @squat_second_attempt_result ||= "not_attempted"
+    @squat_third_attempt_result ||= "not_attempted"
+  end
+
 	# スクワット各試技のバリテーション設定
-	with_options numericality: true, allow_nil: true do
-		validates :squat_first_attempt
-		validates :squat_second_attempt
-		validates :squat_third_attempt
-	end
+	validates :squat_first_attempt, numericality: { allow_nil: true }, if: :should_validate_squat_first_attempt_numericality?
+	validates :squat_second_attempt, numericality: { allow_nil: true }, if: :should_validate_squat_second_attempt_numericality?
+	validates :squat_third_attempt, numericality: { allow_nil: true }, if: :should_validate_squat_third_attempt_numericality?
+
+
 	# スクワット試技判定結果のバリテーション設定
 		# 空は禁止
 	with_options presence: true do
@@ -19,27 +33,43 @@ class Record::Squat
 		validates :squat_second_attempt_result
 		validates :squat_third_attempt_result
 	end
+
 	# 重量の入力があったら成功か、失敗か選択させる
-	validate :squat_first_attempt_is_not_be_not_attempted
-	validate :squat_second_attempt_is_not_be_not_attempted
-	validate :squat_third_attempt_is_not_be_not_attempted
+	validate :squat_first_attempt_is_not_be_not_attempted, unless: :should_validate_squat_first_attempt_numericality?
+	validate :squat_second_attempt_is_not_be_not_attempted, unless: :should_validate_squat_second_attempt_numericality?
+	validate :squat_third_attempt_is_not_be_not_attempted, unless: :should_validate_squat_third_attempt_numericality?
 
 	private
+	# 重量の入力フォームに文字列が入力されていないか？
+	# 第一試技
+	def should_validate_squat_first_attempt_numericality?
+		squat_first_attempt.present? && Float(squat_first_attempt, exception: false).nil?
+	end
+	# 第二試技
+	def should_validate_squat_second_attempt_numericality?
+		squat_second_attempt.present? && Float(squat_second_attempt, exception: false).nil?
+	end
+	# 第三試技
+	def should_validate_squat_third_attempt_numericality?
+		squat_third_attempt.present? && Float(squat_third_attempt, exception: false).nil?
+	end
+
 	# カスタムバリデータ　スクワット判定結果
+	# 第一試技
 	def squat_first_attempt_is_not_be_not_attempted
-		if squat_first_attempt.present? && squat_first_attempt >= 0 && squat_first_attempt_result == "not_attempted"
+		if squat_first_attempt.present? && Float(squat_first_attempt, exception: false) >= 0 && squat_first_attempt_result == "not_attempted"
 			errors.add(:squat_first_attempt_result, "は成功か失敗かを選んでください")
 		end
 	end
-
+	# 第一試技
 	def squat_second_attempt_is_not_be_not_attempted
-		if squat_second_attempt.present? && squat_second_attempt >= 0 && squat_second_attempt_result == "not_attempted"
+		if squat_second_attempt.present? && Float(squat_second_attempt, exception: false) >= 0 && squat_second_attempt_result == "not_attempted"
 			errors.add(:squat_second_attempt_result, "は成功か失敗かを選んでください")
 		end
 	end
-
+	# 第二試技
 	def squat_third_attempt_is_not_be_not_attempted
-		if squat_third_attempt.present? && squat_third_attempt >= 0 && squat_third_attempt_result == "not_attempted"
+		if squat_third_attempt.present? && Float(squat_third_attempt, exception: false) >= 0 && squat_third_attempt_result == "not_attempted"
 			errors.add(:squat_third_attempt_result, "は成功か失敗かを選んでください")
 		end
 	end

--- a/app/models/record/squat.rb
+++ b/app/models/record/squat.rb
@@ -1,0 +1,44 @@
+class Record::Squat
+	include ActiveModel::Model
+	attr_accessor :squat_first_attempt,
+								:squat_second_attempt,
+								:squat_third_attempt,
+								:squat_first_attempt_result,
+								:squat_second_attempt_result,
+								:squat_third_attempt_result
+	# スクワット各試技のバリテーション設定
+	with_options numericality: true, allow_nil: true do
+		validates :squat_first_attempt
+		validates :squat_second_attempt
+		validates :squat_third_attempt
+	end
+	# スクワット試技判定結果のバリテーション設定
+		# 空は禁止
+	with_options presence: true do
+		validates :squat_first_attempt_result
+		validates :squat_second_attempt_result
+		validates :squat_third_attempt_result
+	end
+	# 重量の入力があったら成功か、失敗か選択させる
+	validate :squat_first_attempt_is_not_be_not_attempted
+	validate :squat_second_attempt_is_not_be_not_attempted
+	validate :squat_third_attempt_is_not_be_not_attempted
+	# カスタムバリデータ　スクワット判定結果
+	def squat_first_attempt_is_not_be_not_attempted
+		if squat_first_attempt.present? && squat_first_attempt >= 0 && squat_first_attempt_result == "not_attempted"
+			errors.add(:squat_first_attempt_result, "は成功か失敗かを選んでください")
+		end
+	end
+
+	def squat_second_attempt_is_not_be_not_attempted
+		if squat_second_attempt.present? && squat_second_attempt >= 0 && squat_second_attempt_result == "not_attempted"
+			errors.add(:squat_second_attempt_result, "は成功か失敗かを選んでください")
+		end
+	end
+
+	def squat_third_attempt_is_not_be_not_attempted
+		if squat_third_attempt.present? && squat_third_attempt >= 0 && squat_third_attempt_result == "not_attempted"
+			errors.add(:squat_third_attempt_result, "は成功か失敗かを選んでください")
+		end
+	end
+end

--- a/app/models/record/squat.rb
+++ b/app/models/record/squat.rb
@@ -23,6 +23,8 @@ class Record::Squat
 	validate :squat_first_attempt_is_not_be_not_attempted
 	validate :squat_second_attempt_is_not_be_not_attempted
 	validate :squat_third_attempt_is_not_be_not_attempted
+
+	private
 	# カスタムバリデータ　スクワット判定結果
 	def squat_first_attempt_is_not_be_not_attempted
 		if squat_first_attempt.present? && squat_first_attempt >= 0 && squat_first_attempt_result == "not_attempted"

--- a/app/models/record/weigh_in.rb
+++ b/app/models/record/weigh_in.rb
@@ -1,5 +1,15 @@
 class Record::WeighIn
   include ActiveModel::Model
-  attr_accessor :weight
+  attr_accessor :weight, :competition_id
+
   validates :weight, presence: true, numericality: true
+  validate :unique_competition_id
+
+  private
+
+  def unique_competition_id
+    if CompetitionRecord.exists?(competition_id: competition_id)
+      errors.add(:competition_id, "試技結果はすでに存在しています")
+    end
+  end
 end

--- a/app/models/record/weigh_in.rb
+++ b/app/models/record/weigh_in.rb
@@ -11,7 +11,7 @@ class Record::WeighIn
 
   def unique_competition_id
     if CompetitionRecord.exists?(competition_id: competition_id)
-      errors.add(:competition_id, "試技結果はすでに存在しています")
+      errors.add(:competition_id, "の試技結果はすでに存在しています")
     end
   end
 end

--- a/app/models/record/weigh_in.rb
+++ b/app/models/record/weigh_in.rb
@@ -1,5 +1,7 @@
 class Record::WeighIn
   include ActiveModel::Model
+  include ActiveModel::Validations
+
   attr_accessor :weight, :competition_id
 
   validates :weight, presence: true, numericality: true

--- a/app/models/record/weigh_in.rb
+++ b/app/models/record/weigh_in.rb
@@ -1,0 +1,5 @@
+class Record::WeighIn
+  include ActiveModel::Model
+  attr_accessor :weight
+  validates :weight, presence: true, numericality: true
+end

--- a/app/views/competition_records/_competition_record.html.erb
+++ b/app/views/competition_records/_competition_record.html.erb
@@ -164,7 +164,7 @@
     </div>
   </div>
   <div class="flex justify-end w-full">
-    <%= link_to "編集", edit_competition_competition_record_path(competition), class: "btn btn-sm btn-primary max-w-24 mx-2" %>
-    <%= link_to "削除", competition_competition_record_path(competition), data: {turbo_method: :delete, turbo_confirm: "削除しますか？"}, class: "btn btn-sm btn-error max-w-24" %>
+    <%= link_to "編集", '#', class: "btn btn-sm btn-primary max-w-24 mx-2" %>
+    <%= link_to "削除", '#', data: {turbo_method: :delete, turbo_confirm: "削除しますか？"}, class: "btn btn-sm btn-error max-w-24" %>
   </div>
 </div>

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -48,7 +48,7 @@
       <% else %>
         <div class="flex-col flex justify-center items-center w-full">
           <p>大会結果記録はまだ未登録です</p>
-          <%= link_to "大会結果記録", new_competition_competition_record_path(@competition), class: "btn btn-sm btn-primary max-w-24" %>
+          <%= link_to "大会結果記録", new_competition_weigh_in_path(@competition), class: "btn btn-sm btn-primary max-w-24" %>
         </div>
       <% end %>
     </div>

--- a/app/views/record/bench_presses/new.html.erb
+++ b/app/views/record/bench_presses/new.html.erb
@@ -1,73 +1,125 @@
-<div class="hero min-h-screen bg-base-200">
+<div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
-      <!-- ここからform_withを使う形に修正 -->
-      <h1 class="text-2xl text-center">試技結果の登録</h1>
+      <div class="mb-5">
+				<ul class="steps">
+					<li class="step step-primary text-[10px]">検量体重</li>
+					<li class="step step-primary text-[10px]">スクワット</li>
+					<li class="step step-primary text-[10px] text-orange-600 font-bold">ベンチプレス</li>
+					<li class="step text-[10px]">デッドリフト</li>
+					<li class="step text-[10px]">振り返り<br>コメント</li>
+				</ul>
+			</div>
+      <h1 class="text-2xl text-center mb-5">ベンチプレス結果登録</h1>
 			<%= form_with model: @bench_press, url: competition_bench_presse_path(@competition)  do |f| %>
-			<!-- ベンチプレス試技結果 -->
+				<!-- ベンチプレス試技結果 -->
 				<!-- ベンチプレス第１試技 -->
-				<div class="flex flex-col mb-6">
-					<div class="flex justify-between">
-						<label class="form-control flex-grow mr-2">
-							<%= f.label :benchpress_first_attempt %>
-							<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
-						</label>
-						<label class="form-control flex-grow">
-							<div class="label p-0 flex justify-start items-center">
-								<%= f.label :benchpress_first_attempt_result, class: 'mr-2' %>
-								<p class="text-red-500">(※)</p>
-							</div>
-							<%= f.select :benchpress_first_attempt_result,
-							CompetitionRecord.benchpress_first_attempt_results_i18n.invert.map { |key, value| [key, value] },
-							{include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
-						</label>
-					</div>
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :benchpress_first_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
 						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_first_attempt %>
+					</div>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_first_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_first_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
 						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_first_attempt_result %>
 					</div>
+				</div>
 				<!-- ベンチプレス第2試技 -->
-				<div class="flex flex-col mb-6">
-					<div class="flex justify-between">
-						<label class="form-control flex-grow mr-2">
-							<%= f.label :benchpress_second_attempt %>
-							<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
-						</label>
-						<label class="form-control flex-grow">
-							<div class="label p-0 flex justify-start items-center">
-								<%= f.label :benchpress_second_attempt_result, class: 'mr-2' %>
-								<p class="text-red-500">(※)</p>
-							</div>
-							<%= f.select :benchpress_second_attempt_result,
-							CompetitionRecord.benchpress_second_attempt_results_i18n.invert.map { |key, value| [key, value] },
-							{include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
-						</label>
-					</div>
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :benchpress_second_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
 						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_second_attempt %>
+					</div>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_second_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_second_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
 						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_second_attempt_result %>
+					</div>
 				</div>
 				<!-- ベンチプレス第3試技 -->
-				<div class="flex flex-col mb-6">
-					<div class="flex justify-between">
-						<label class="form-control flex-grow mr-2">
-							<%= f.label :benchpress_third_attempt %>
-							<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
-						</label>
-						<label class="form-control flex-grow">
-							<div class="label p-0 flex justify-start items-center">
-								<%= f.label :benchpress_third_attempt_result, class: 'mr-2' %>
-								<p class="text-red-500">(※)</p>
-							</div>
-							<%= f.select :benchpress_third_attempt_result,
-							CompetitionRecord.benchpress_third_attempt_results_i18n.invert.map { |key, value| [key, value] },
-							{include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
-						</label>
-					</div>
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :benchpress_third_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
 						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_third_attempt %>
+					</div>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_third_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_third_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
 						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_third_attempt_result %>
+					</div>
 				</div>
-			<!-- ボタン -->
-				<div class="form-control mt-6">
-						<%= f.submit class: 'btn btn-primary' %>
+				<!-- ボタン -->
+				<div class="form-control mt-6 flex flex-row justify-center">
+					<div>
+						<%= f.submit "次の種目へ", class: 'btn btn-secondary btn-sm w-24' %>
+					</div>
 				</div>
 			<% end %>
       <!-- ここまでform_withを使う形に修正 -->

--- a/app/views/record/bench_presses/new.html.erb
+++ b/app/views/record/bench_presses/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Record::BenchPresses#new</h1>
+<p>Find me in app/views/record/bench_presses/new.html.erb</p>

--- a/app/views/record/bench_presses/new.html.erb
+++ b/app/views/record/bench_presses/new.html.erb
@@ -1,2 +1,76 @@
-<h1>Record::BenchPresses#new</h1>
-<p>Find me in app/views/record/bench_presses/new.html.erb</p>
+<div class="hero min-h-screen bg-base-200">
+  <div class="hero-content flex-col">
+    <div class="items-center mx-auto max-w-80 min-w-80">
+      <!-- ここからform_withを使う形に修正 -->
+      <h1 class="text-2xl text-center">試技結果の登録</h1>
+			<%= form_with model: @bench_press, url: competition_bench_presse_path(@competition)  do |f| %>
+			<!-- ベンチプレス試技結果 -->
+				<!-- ベンチプレス第１試技 -->
+				<div class="flex flex-col mb-6">
+					<div class="flex justify-between">
+						<label class="form-control flex-grow mr-2">
+							<%= f.label :benchpress_first_attempt %>
+							<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+						</label>
+						<label class="form-control flex-grow">
+							<div class="label p-0 flex justify-start items-center">
+								<%= f.label :benchpress_first_attempt_result, class: 'mr-2' %>
+								<p class="text-red-500">(※)</p>
+							</div>
+							<%= f.select :benchpress_first_attempt_result,
+							CompetitionRecord.benchpress_first_attempt_results_i18n.invert.map { |key, value| [key, value] },
+							{include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+						</label>
+					</div>
+						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_first_attempt %>
+						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_first_attempt_result %>
+					</div>
+				<!-- ベンチプレス第2試技 -->
+				<div class="flex flex-col mb-6">
+					<div class="flex justify-between">
+						<label class="form-control flex-grow mr-2">
+							<%= f.label :benchpress_second_attempt %>
+							<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+						</label>
+						<label class="form-control flex-grow">
+							<div class="label p-0 flex justify-start items-center">
+								<%= f.label :benchpress_second_attempt_result, class: 'mr-2' %>
+								<p class="text-red-500">(※)</p>
+							</div>
+							<%= f.select :benchpress_second_attempt_result,
+							CompetitionRecord.benchpress_second_attempt_results_i18n.invert.map { |key, value| [key, value] },
+							{include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+						</label>
+					</div>
+						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_second_attempt %>
+						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_second_attempt_result %>
+				</div>
+				<!-- ベンチプレス第3試技 -->
+				<div class="flex flex-col mb-6">
+					<div class="flex justify-between">
+						<label class="form-control flex-grow mr-2">
+							<%= f.label :benchpress_third_attempt %>
+							<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+						</label>
+						<label class="form-control flex-grow">
+							<div class="label p-0 flex justify-start items-center">
+								<%= f.label :benchpress_third_attempt_result, class: 'mr-2' %>
+								<p class="text-red-500">(※)</p>
+							</div>
+							<%= f.select :benchpress_third_attempt_result,
+							CompetitionRecord.benchpress_third_attempt_results_i18n.invert.map { |key, value| [key, value] },
+							{include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+						</label>
+					</div>
+						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_third_attempt %>
+						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_third_attempt_result %>
+				</div>
+			<!-- ボタン -->
+				<div class="form-control mt-6">
+						<%= f.submit class: 'btn btn-primary' %>
+				</div>
+			<% end %>
+      <!-- ここまでform_withを使う形に修正 -->
+    </div>
+  </div>
+</div>

--- a/app/views/record/comments/new.html.erb
+++ b/app/views/record/comments/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Record::Comments#new</h1>
+<p>Find me in app/views/record/comments/new.html.erb</p>

--- a/app/views/record/comments/new.html.erb
+++ b/app/views/record/comments/new.html.erb
@@ -1,23 +1,31 @@
-<div class="hero min-h-screen bg-base-200">
+<div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
-      <!-- ここからform_withを使う形に修正 -->
-      <h1 class="text-2xl text-center">試技結果の登録</h1>
-      <%= form_with model: @comment, url: competition_comment_path(@competition)  do |f| %>
-        <!-- 振り返りコメント -->
-        <label class="form-control mb-6">
-          <div class="label p-0 flex justify-start items-center">
-            <%= f.label :comment, class: 'mr-2'%>
-            <p class="text-slate-500">(任意)</p>
-          </div>
-            <%= f.text_area :comment, class:"textarea textarea-bordered", placeholder:"振り返りコメント" %>
-        </label>
-        <!-- ボタン -->
-        <div class="form-control mt-6">
-            <%= f.submit class: 'btn btn-primary' %>
-        </div>
-      <% end %>
-      <!-- ここまでform_withを使う形に修正 -->
+      <div class="mb-5">
+				<ul class="steps">
+					<li class="step step-primary text-[10px]">検量体重</li>
+					<li class="step step-primary text-[10px]">スクワット</li>
+					<li class="step step-primary text-[10px]">ベンチプレス</li>
+					<li class="step step-primary text-[10px]">デッドリフト</li>
+					<li class="step step-primary text-[10px] text-orange-600 font-bold">振り返り<br>コメント</li>
+				</ul>
+			</div>
+      <h1 class="text-2xl text-center mb-5">振り返りコメント</h1>
+			  <%= form_with model: @comment, url: competition_comment_path(@competition)  do |f| %>
+          <!-- 振り返りコメント -->
+          <label class="form-control mb-6">
+            <div class="label p-0 flex justify-start items-center">
+              <p class="text-slate-500">(任意)</p>
+            </div>
+              <%= f.text_area :comment, class:"textarea textarea-bordered h-80" %>
+          </label>
+          <!-- ボタン -->
+          <div class="form-control mt-6 flex flex-row justify-center">
+            <div>
+              <%= f.submit class: 'btn btn-secondary btn-sm w-24' %>
+            </div>
+				  </div>
+        <% end %>
     </div>
   </div>
 </div>

--- a/app/views/record/comments/new.html.erb
+++ b/app/views/record/comments/new.html.erb
@@ -1,2 +1,23 @@
-<h1>Record::Comments#new</h1>
-<p>Find me in app/views/record/comments/new.html.erb</p>
+<div class="hero min-h-screen bg-base-200">
+  <div class="hero-content flex-col">
+    <div class="items-center mx-auto max-w-80 min-w-80">
+      <!-- ここからform_withを使う形に修正 -->
+      <h1 class="text-2xl text-center">試技結果の登録</h1>
+      <%= form_with model: @comment, url: competition_comment_path(@competition)  do |f| %>
+        <!-- 振り返りコメント -->
+        <label class="form-control mb-6">
+          <div class="label p-0 flex justify-start items-center">
+            <%= f.label :comment, class: 'mr-2'%>
+            <p class="text-slate-500">(任意)</p>
+          </div>
+            <%= f.text_area :comment, class:"textarea textarea-bordered", placeholder:"振り返りコメント" %>
+        </label>
+        <!-- ボタン -->
+        <div class="form-control mt-6">
+            <%= f.submit class: 'btn btn-primary' %>
+        </div>
+      <% end %>
+      <!-- ここまでform_withを使う形に修正 -->
+    </div>
+  </div>
+</div>

--- a/app/views/record/deadlifts/new.html.erb
+++ b/app/views/record/deadlifts/new.html.erb
@@ -1,2 +1,76 @@
-<h1>Record::Deadlifts#new</h1>
-<p>Find me in app/views/record/deadlifts/new.html.erb</p>
+<div class="hero min-h-screen bg-base-200">
+  <div class="hero-content flex-col">
+    <div class="items-center mx-auto max-w-80 min-w-80">
+      <!-- ここからform_withを使う形に修正 -->
+      <h1 class="text-2xl text-center">試技結果の登録</h1>
+      <%= form_with model: @dedlift, url: competition_deadlift_path(@competition)  do |f| %>
+        <!-- デッドリフト試技結果 -->
+        <!-- デッドリフト第１試技 -->
+        <div class="flex flex-col mb-6">
+          <div class="flex justify-between">
+            <label class="form-control flex-grow mr-2">
+              <%= f.label :deadlift_first_attempt %>
+              <%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+            </label>
+            <label class="form-control flex-grow">
+              <div class="label p-0 flex justify-start items-center">
+                <%= f.label :deadlift_first_attempt_result, class: 'mr-2' %>
+                <p class="text-red-500">(※)</p>
+              </div>
+              <%= f.select :deadlift_first_attempt_result,
+              CompetitionRecord.deadlift_first_attempt_results_i18n.invert.map { |key, value| [key, value] },
+              {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+            </label>
+          </div>
+            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_first_attempt %>
+            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_first_attempt_result %>
+          </div>
+        <!-- デッドリフト第2試技 -->
+        <div class="flex flex-col mb-6">
+          <div class="flex justify-between">
+            <label class="form-control flex-grow mr-2">
+              <%= f.label :deadlift_second_attempt %>
+              <%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+            </label>
+            <label class="form-control flex-grow">
+              <div class="label p-0 flex justify-start items-center">
+                <%= f.label :deadlift_second_attempt_result, class: 'mr-2' %>
+                <p class="text-red-500">(※)</p>
+              </div>
+              <%= f.select :deadlift_second_attempt_result,
+              CompetitionRecord.deadlift_second_attempt_results_i18n.invert.map { |key, value| [key, value] },
+              {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+            </label>
+          </div>
+            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_second_attempt %>
+            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_second_attempt_result %>
+        </div>
+        <!-- デッドリフト第3試技 -->
+        <div class="flex flex-col mb-6">
+          <div class="flex justify-between">
+            <label class="form-control flex-grow mr-2">
+              <%= f.label :deadlift_third_attempt %>
+              <%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+            </label>
+            <label class="form-control flex-grow">
+              <div class="label p-0 flex justify-start items-center">
+                <%= f.label :deadlift_third_attempt_result, class: 'mr-2' %>
+                <p class="text-red-500">(※)</p>
+              </div>
+              <%= f.select :deadlift_third_attempt_result,
+              CompetitionRecord.deadlift_third_attempt_results_i18n.invert.map { |key, value| [key, value] },
+              {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+            </label>
+          </div>
+            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_third_attempt %>
+            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_third_attempt_result %>
+        </div>
+        <!-- ボタン -->
+        <div class="form-control mt-6">
+            <%= f.submit class: 'btn btn-primary' %>
+        </div>
+      <% end %>
+      <!-- ここまでform_withを使う形に修正 -->
+    </div>
+  </div>
+</div>

--- a/app/views/record/deadlifts/new.html.erb
+++ b/app/views/record/deadlifts/new.html.erb
@@ -1,75 +1,127 @@
-<div class="hero min-h-screen bg-base-200">
+<div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
-      <!-- ここからform_withを使う形に修正 -->
-      <h1 class="text-2xl text-center">試技結果の登録</h1>
-      <%= form_with model: @dedlift, url: competition_deadlift_path(@competition)  do |f| %>
-        <!-- デッドリフト試技結果 -->
-        <!-- デッドリフト第１試技 -->
-        <div class="flex flex-col mb-6">
-          <div class="flex justify-between">
-            <label class="form-control flex-grow mr-2">
-              <%= f.label :deadlift_first_attempt %>
-              <%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
-            </label>
-            <label class="form-control flex-grow">
-              <div class="label p-0 flex justify-start items-center">
-                <%= f.label :deadlift_first_attempt_result, class: 'mr-2' %>
-                <p class="text-red-500">(※)</p>
-              </div>
-              <%= f.select :deadlift_first_attempt_result,
-              CompetitionRecord.deadlift_first_attempt_results_i18n.invert.map { |key, value| [key, value] },
-              {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
-            </label>
-          </div>
-            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_first_attempt %>
-            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_first_attempt_result %>
-          </div>
-        <!-- デッドリフト第2試技 -->
-        <div class="flex flex-col mb-6">
-          <div class="flex justify-between">
-            <label class="form-control flex-grow mr-2">
-              <%= f.label :deadlift_second_attempt %>
-              <%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
-            </label>
-            <label class="form-control flex-grow">
-              <div class="label p-0 flex justify-start items-center">
-                <%= f.label :deadlift_second_attempt_result, class: 'mr-2' %>
-                <p class="text-red-500">(※)</p>
-              </div>
-              <%= f.select :deadlift_second_attempt_result,
-              CompetitionRecord.deadlift_second_attempt_results_i18n.invert.map { |key, value| [key, value] },
-              {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
-            </label>
-          </div>
-            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_second_attempt %>
-            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_second_attempt_result %>
-        </div>
-        <!-- デッドリフト第3試技 -->
-        <div class="flex flex-col mb-6">
-          <div class="flex justify-between">
-            <label class="form-control flex-grow mr-2">
-              <%= f.label :deadlift_third_attempt %>
-              <%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
-            </label>
-            <label class="form-control flex-grow">
-              <div class="label p-0 flex justify-start items-center">
-                <%= f.label :deadlift_third_attempt_result, class: 'mr-2' %>
-                <p class="text-red-500">(※)</p>
-              </div>
-              <%= f.select :deadlift_third_attempt_result,
-              CompetitionRecord.deadlift_third_attempt_results_i18n.invert.map { |key, value| [key, value] },
-              {include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
-            </label>
-          </div>
-            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_third_attempt %>
-            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_third_attempt_result %>
-        </div>
-        <!-- ボタン -->
-        <div class="form-control mt-6">
-            <%= f.submit class: 'btn btn-primary' %>
-        </div>
-      <% end %>
+      <div class="mb-5">
+				<ul class="steps">
+					<li class="step step-primary text-[10px]">検量体重</li>
+					<li class="step step-primary text-[10px]">スクワット</li>
+					<li class="step step-primary text-[10px]">ベンチプレス</li>
+					<li class="step step-primary text-[10px] text-orange-600 font-bold">デッドリフト</li>
+					<li class="step text-[10px]">振り返り<br>コメント</li>
+				</ul>
+			</div>
+      <h1 class="text-2xl text-center mb-5">デッドリフト結果登録</h1>
+			<%= form_with model: @deadlift, url: competition_deadlift_path(@competition)  do |f| %>
+				<!-- デッドリフト試技結果 -->
+				<!-- デッドリフト第１試技 -->
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :deadlift_first_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
+						<%= render 'shared/error_messages', object: f.object, attribute: :deadlift_first_attempt %>
+					</div>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_first_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_first_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
+						<%= render 'shared/error_messages', object: f.object, attribute: :deadlift_first_attempt_result %>
+					</div>
+				</div>
+				<!-- デッドリフト第2試技 -->
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :deadlift_second_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
+						<%= render 'shared/error_messages', object: f.object, attribute: :deadlift_second_attempt %>
+					</div>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_second_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_second_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
+						<%= render 'shared/error_messages', object: f.object, attribute: :deadlift_second_attempt_result %>
+					</div>
+				</div>
+				<!-- デッドリフト第3試技 -->
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :deadlift_third_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
+						<%= render 'shared/error_messages', object: f.object, attribute: :deadlift_third_attempt %>
+					</div>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_third_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_third_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
+						<%= render 'shared/error_messages', object: f.object, attribute: :deadlift_third_attempt_result %>
+					</div>
+				</div>
+				<!-- ボタン -->
+				<div class="form-control mt-6 flex flex-row justify-center">
+					<div>
+						<%= f.submit "次の種目へ", class: 'btn btn-secondary btn-sm w-24' %>
+					</div>
+				</div>
+			<% end %>
       <!-- ここまでform_withを使う形に修正 -->
     </div>
   </div>

--- a/app/views/record/deadlifts/new.html.erb
+++ b/app/views/record/deadlifts/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Record::Deadlifts#new</h1>
+<p>Find me in app/views/record/deadlifts/new.html.erb</p>

--- a/app/views/record/squats/new.html.erb
+++ b/app/views/record/squats/new.html.erb
@@ -1,8 +1,16 @@
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
-      <!-- ここからform_withを使う形に修正 -->
-      <h1 class="text-2xl text-center mb-10">スクワット</h1>
+      <div class="mb-5">
+				<ul class="steps">
+					<li class="step step-primary text-[10px]">検量体重</li>
+					<li class="step step-primary text-[10px] text-orange-600 font-bold">スクワット</li>
+					<li class="step text-[10px]">ベンチプレス</li>
+					<li class="step text-[10px]">デッドリフト</li>
+					<li class="step text-[10px]">振り返り<br>コメント</li>
+				</ul>
+			</div>
+      <h1 class="text-2xl text-center mb-5">スクワット結果登録</h1>
 			<%= form_with model: @squat, url: competition_squat_path(@competition)  do |f| %>
 				<!-- スクワット試技結果 -->
 				<!-- スクワット第１試技 -->
@@ -108,8 +116,10 @@
 					</div>
 				</div>
 				<!-- ボタン -->
-				<div class="form-control mt-6">
-						<%= f.submit class: 'btn btn-primary' %>
+				<div class="form-control mt-6 flex flex-row justify-center">
+					<div>
+						<%= f.submit "次の種目へ", class: 'btn btn-secondary btn-sm w-24' %>
+					</div>
 				</div>
 			<% end %>
       <!-- ここまでform_withを使う形に修正 -->

--- a/app/views/record/squats/new.html.erb
+++ b/app/views/record/squats/new.html.erb
@@ -1,2 +1,76 @@
-<h1>Record::Squats#new</h1>
-<p>Find me in app/views/record/squats/new.html.erb</p>
+<div class="hero min-h-screen bg-base-200">
+  <div class="hero-content flex-col">
+    <div class="items-center mx-auto max-w-80 min-w-80">
+      <!-- ここからform_withを使う形に修正 -->
+      <h1 class="text-2xl text-center">試技結果の登録</h1>
+			<%= form_with model: @squat, url: competition_squat_path(@competition)  do |f| %>
+				<!-- スクワット試技結果 -->
+				<!-- スクワット第１試技 -->
+				<div class="flex flex-col mb-6">
+					<div class="flex justify-between">
+						<label class="form-control flex-grow mr-2">
+							<%= f.label :squat_first_attempt %>
+							<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+						</label>
+						<label class="form-control flex-grow">
+							<div class="label p-0 flex justify-start items-center">
+								<%= f.label :squat_first_attempt_result, class: 'mr-2' %>
+								<p class="text-red-500">(※)</p>
+							</div>
+							<%= f.select :squat_first_attempt_result,
+							CompetitionRecord.squat_first_attempt_results_i18n.invert.map { |key, value| [key, value] },
+							{include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+						</label>
+					</div>
+					<%= render 'shared/error_messages', object: f.object, attribute: :squat_first_attempt %>
+					<%= render 'shared/error_messages', object: f.object, attribute: :squat_first_attempt_result %>
+				</div>
+				<!-- スクワット第2試技 -->
+				<div class="flex flex-col mb-6">
+					<div class="flex justify-between">
+						<label class="form-control flex-grow mr-2">
+							<%= f.label :squat_second_attempt %>
+							<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+						</label>
+						<label class="form-control flex-grow">
+							<div class="label p-0 flex justify-start items-center">
+								<%= f.label :squat_second_attempt_result, class: 'mr-2' %>
+								<p class="text-red-500">(※)</p>
+							</div>
+							<%= f.select :squat_second_attempt_result,
+							CompetitionRecord.squat_second_attempt_results_i18n.invert.map { |key, value| [key, value] },
+							{include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+						</label>
+					</div>
+					<%= render 'shared/error_messages', object: f.object, attribute: :squat_second_attempt %>
+					<%= render 'shared/error_messages', object: f.object, attribute: :squat_second_attempt_result %>
+				</div>
+				<!-- スクワット第3試技 -->
+				<div class="flex flex-col mb-6">
+					<div class="flex justify-between">
+						<label class="form-control flex-grow mr-2">
+							<%= f.label :squat_third_attempt %>
+							<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
+						</label>
+						<label class="form-control flex-grow">
+							<div class="label p-0 flex justify-start items-center">
+								<%= f.label :squat_third_attempt_result, class: 'mr-2' %>
+								<p class="text-red-500">(※)</p>
+							</div>
+							<%= f.select :squat_third_attempt_result,
+							CompetitionRecord.squat_third_attempt_results_i18n.invert.map { |key, value| [key, value] },
+							{include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
+						</label>
+					</div>
+					<%= render 'shared/error_messages', object: f.object, attribute: :squat_third_attempt %>
+					<%= render 'shared/error_messages', object: f.object, attribute: :squat_third_attempt_result %>
+				</div>
+				<!-- ボタン -->
+				<div class="form-control mt-6">
+						<%= f.submit class: 'btn btn-primary' %>
+				</div>
+			<% end %>
+      <!-- ここまでform_withを使う形に修正 -->
+    </div>
+  </div>
+</div>

--- a/app/views/record/squats/new.html.erb
+++ b/app/views/record/squats/new.html.erb
@@ -1,69 +1,111 @@
-<div class="hero min-h-screen bg-base-200">
+<div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
       <!-- ここからform_withを使う形に修正 -->
-      <h1 class="text-2xl text-center">試技結果の登録</h1>
+      <h1 class="text-2xl text-center mb-10">スクワット</h1>
 			<%= form_with model: @squat, url: competition_squat_path(@competition)  do |f| %>
 				<!-- スクワット試技結果 -->
 				<!-- スクワット第１試技 -->
-				<div class="flex flex-col mb-6">
-					<div class="flex justify-between">
-						<label class="form-control flex-grow mr-2">
-							<%= f.label :squat_first_attempt %>
-							<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
-						</label>
-						<label class="form-control flex-grow">
-							<div class="label p-0 flex justify-start items-center">
-								<%= f.label :squat_first_attempt_result, class: 'mr-2' %>
-								<p class="text-red-500">(※)</p>
-							</div>
-							<%= f.select :squat_first_attempt_result,
-							CompetitionRecord.squat_first_attempt_results_i18n.invert.map { |key, value| [key, value] },
-							{include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
-						</label>
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :squat_first_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
+						<%= render 'shared/error_messages', object: f.object, attribute: :squat_first_attempt %>
 					</div>
-					<%= render 'shared/error_messages', object: f.object, attribute: :squat_first_attempt %>
-					<%= render 'shared/error_messages', object: f.object, attribute: :squat_first_attempt_result %>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :squat_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_first_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :squat_first_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_first_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :squat_first_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_first_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
+						<%= render 'shared/error_messages', object: f.object, attribute: :squat_first_attempt_result %>
+					</div>
 				</div>
 				<!-- スクワット第2試技 -->
-				<div class="flex flex-col mb-6">
-					<div class="flex justify-between">
-						<label class="form-control flex-grow mr-2">
-							<%= f.label :squat_second_attempt %>
-							<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
-						</label>
-						<label class="form-control flex-grow">
-							<div class="label p-0 flex justify-start items-center">
-								<%= f.label :squat_second_attempt_result, class: 'mr-2' %>
-								<p class="text-red-500">(※)</p>
-							</div>
-							<%= f.select :squat_second_attempt_result,
-							CompetitionRecord.squat_second_attempt_results_i18n.invert.map { |key, value| [key, value] },
-							{include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
-						</label>
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :squat_second_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
+						<%= render 'shared/error_messages', object: f.object, attribute: :squat_second_attempt %>
 					</div>
-					<%= render 'shared/error_messages', object: f.object, attribute: :squat_second_attempt %>
-					<%= render 'shared/error_messages', object: f.object, attribute: :squat_second_attempt_result %>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :squat_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_second_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :squat_second_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_second_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :squat_second_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_second_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
+						<%= render 'shared/error_messages', object: f.object, attribute: :squat_second_attempt_result %>
+					</div>
 				</div>
 				<!-- スクワット第3試技 -->
-				<div class="flex flex-col mb-6">
-					<div class="flex justify-between">
-						<label class="form-control flex-grow mr-2">
-							<%= f.label :squat_third_attempt %>
-							<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-full', placeholder:"重量を入力してください" %>
-						</label>
-						<label class="form-control flex-grow">
-							<div class="label p-0 flex justify-start items-center">
-								<%= f.label :squat_third_attempt_result, class: 'mr-2' %>
-								<p class="text-red-500">(※)</p>
-							</div>
-							<%= f.select :squat_third_attempt_result,
-							CompetitionRecord.squat_third_attempt_results_i18n.invert.map { |key, value| [key, value] },
-							{include_blank: '判定結果'}, { class: 'select select-bordered rounded select-sm w-full' } %>
-						</label>
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :squat_third_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
+						<%= render 'shared/error_messages', object: f.object, attribute: :squat_third_attempt %>
 					</div>
-					<%= render 'shared/error_messages', object: f.object, attribute: :squat_third_attempt %>
-					<%= render 'shared/error_messages', object: f.object, attribute: :squat_third_attempt_result %>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :squat_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_third_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :squat_third_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_third_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :squat_third_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_third_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
+						<%= render 'shared/error_messages', object: f.object, attribute: :squat_third_attempt_result %>
+					</div>
 				</div>
 				<!-- ボタン -->
 				<div class="form-control mt-6">

--- a/app/views/record/squats/new.html.erb
+++ b/app/views/record/squats/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Record::Squats#new</h1>
+<p>Find me in app/views/record/squats/new.html.erb</p>

--- a/app/views/record/weigh_ins/new.html.erb
+++ b/app/views/record/weigh_ins/new.html.erb
@@ -1,2 +1,23 @@
-<h1>Record::WeighIns#new</h1>
-<p>Find me in app/views/record/weigh_ins/new.html.erb</p>
+<div class="hero min-h-screen bg-base-200">
+  <div class="hero-content flex-col">
+    <div class="items-center mx-auto max-w-80 min-w-80">
+      <!-- ここからform_withを使う形に修正 -->
+      <h1 class="text-2xl text-center">試技結果の登録</h1>
+			<%= form_with model: @weigh_in, url: competition_weigh_in_path(@competition)  do |f| %>
+				<label class="form-control w-full mb-6">
+					<div class="label p-0 flex justify-start items-center">
+						<%= f.label :weight, class: 'mr-2'%>
+						<p class="text-red-500">(必須)</p>
+					</div>
+					<%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-full', placeholder:"検量体重"%>
+					<%= render 'shared/error_messages', object: f.object, attribute: :weight %>
+				</label>
+			<!-- ボタン -->
+				<div class="form-control mt-6">
+						<%= f.submit class: 'btn btn-primary' %>
+				</div>
+			<% end %>
+      <!-- ここまでform_withを使う形に修正 -->
+    </div>
+  </div>
+</div>

--- a/app/views/record/weigh_ins/new.html.erb
+++ b/app/views/record/weigh_ins/new.html.erb
@@ -1,23 +1,39 @@
-<div class="hero min-h-screen bg-base-200">
+<div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
-      <!-- ここからform_withを使う形に修正 -->
-      <h1 class="text-2xl text-center">試技結果の登録</h1>
+      <div class="mb-5">
+				<ul class="steps">
+					<li class="step step-primary text-[10px] text-orange-600 font-bold">検量体重</li>
+					<li class="step text-[10px]">スクワット</li>
+					<li class="step text-[10px]">ベンチプレス</li>
+					<li class="step text-[10px]">デッドリフト</li>
+					<li class="step text-[10px]">振り返り<br>コメント</li>
+				</ul>
+			</div>
+      <h1 class="text-2xl text-center mb-5">検量体重登録</h1>
 			<%= form_with model: @weigh_in, url: competition_weigh_in_path(@competition)  do |f| %>
-				<label class="form-control w-full mb-6">
-					<div class="label p-0 flex justify-start items-center">
-						<%= f.label :weight, class: 'mr-2'%>
-						<p class="text-red-500">(必須)</p>
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<div class="flex justify-between">
+						<div class="label p-0 flex justify-start items-center">
+							<%= f.label :weight, class: 'mr-2'%>
+							<p class="text-red-500">(必須)</p>
+						</div>
+						<label class="form-control flex flex-row">
+							<%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder:"検量体重"%>
+							<span>kg</span>
+						</label>
 					</div>
-					<%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-full', placeholder:"検量体重"%>
 					<%= render 'shared/error_messages', object: f.object, attribute: :weight %>
-				</label>
-			<!-- ボタン -->
-				<div class="form-control mt-6">
-						<%= f.submit class: 'btn btn-primary' %>
+					<%= render 'shared/error_messages', object: f.object, attribute: :competition_id %>
 				</div>
+			<!-- ボタン -->
+			<div class="form-control mt-6 flex flex-row justify-center">
+				<div>
+					<%= f.submit "次の種目へ", class: 'btn btn-secondary btn-sm w-24' %>
+				</div>
+			</div>
 			<% end %>
-      <!-- ここまでform_withを使う形に修正 -->
     </div>
   </div>
 </div>
+

--- a/app/views/record/weigh_ins/new.html.erb
+++ b/app/views/record/weigh_ins/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Record::WeighIns#new</h1>
+<p>Find me in app/views/record/weigh_ins/new.html.erb</p>

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -2,6 +2,9 @@ ja:
   # acrivremodel用のロケールファイル
   activemodel:
       attributes:
+        record/weigh_in:
+          weight: "体重"
+          competition_id: "この大会の"
         record/squat:
           squat_first_attempt: "第1試技"
           squat_second_attempt: "第2試技"

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -1,0 +1,26 @@
+ja:
+  # acrivremodel用のロケールファイル
+  activemodel:
+      attributes:
+        record/squat:
+          squat_first_attempt: "第1試技"
+          squat_second_attempt: "第2試技"
+          squat_third_attempt: "第3試技"
+          squat_first_attempt_result: "第1試技結果"
+          squat_second_attempt_result: "第2試技結果"
+          squat_third_attempt_result: "第3試技結果"
+        record/benchpress:
+          benchpress_first_attempt: "第1試技"
+          benchpress_second_attempt: "第2試技"
+          benchpress_third_attempt: "第3試技"
+          benchpress_first_attempt_result: "試技結果"
+          benchpress_second_attempt_result: "試技結果"
+          benchpress_third_attempt_result: "試技結果"
+        record/deadlift:
+          deadlift_first_attempt: "第1試技"
+          deadlift_second_attempt: "第2試技"
+          deadlift_third_attempt: "第3試技"
+          deadlift_first_attempt_result: "試技結果"
+          deadlift_second_attempt_result: "試技結果"
+          deadlift_third_attempt_result: "試技結果"
+

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -9,7 +9,7 @@ ja:
           squat_first_attempt_result: "第1試技結果"
           squat_second_attempt_result: "第2試技結果"
           squat_third_attempt_result: "第3試技結果"
-        record/benchpress:
+        record/bench_press:
           benchpress_first_attempt: "第1試技"
           benchpress_second_attempt: "第2試技"
           benchpress_third_attempt: "第3試技"

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -23,4 +23,5 @@ ja:
           deadlift_first_attempt_result: "試技結果"
           deadlift_second_attempt_result: "試技結果"
           deadlift_third_attempt_result: "試技結果"
-
+        record/comment:
+          comment: "振り返りを書いてみましょう"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,21 +1,20 @@
 Rails.application.routes.draw do
-  namespace :record do
-    get 'comments/new'
-    get 'comments/create'
-    get 'deadlifts/new'
-    get 'deadlifts/create'
-    get 'bench_presses/new'
-    get 'bench_presses/create'
-    get 'squats/new'
-    get 'squats/create'
-  end
   root "tops#index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   resources :users, only: [:create, :new, :edit, :update]
   resource :profile, only: [:show, :edit, :update]
   resources :password_resets, only: [:create, :edit, :update, :new]
+
   resources :competitions do
-    resource :competition_record, only: [:create, :new, :edit, :update, :destroy]
+    resource :competition_record, only: [:destroy]
+    scope module: 'record' do
+      # 各ステップのルーティング
+      resource :weigh_in, only: [:new, :create]
+      resource :squat, only: [:new, :create]
+      resource :bench_presse, only: [:new, :create]
+      resource :deadlift, only: [:new, :create]
+      resource :comment, only: [:new, :create]
+    end
   end
   # Defines the root path route ("/")
   # root "articles#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,14 @@
 Rails.application.routes.draw do
+  namespace :record do
+    get 'comments/new'
+    get 'comments/create'
+    get 'deadlifts/new'
+    get 'deadlifts/create'
+    get 'bench_presses/new'
+    get 'bench_presses/create'
+    get 'squats/new'
+    get 'squats/create'
+  end
   root "tops#index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   resources :users, only: [:create, :new, :edit, :update]

--- a/test/controllers/record/bench_presses_controller_test.rb
+++ b/test/controllers/record/bench_presses_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Record::BenchPressesControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get record_bench_presses_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get record_bench_presses_create_url
+    assert_response :success
+  end
+end

--- a/test/controllers/record/comments_controller_test.rb
+++ b/test/controllers/record/comments_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Record::CommentsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get record_comments_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get record_comments_create_url
+    assert_response :success
+  end
+end

--- a/test/controllers/record/deadlifts_controller_test.rb
+++ b/test/controllers/record/deadlifts_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Record::DeadliftsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get record_deadlifts_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get record_deadlifts_create_url
+    assert_response :success
+  end
+end

--- a/test/controllers/record/squats_controller_test.rb
+++ b/test/controllers/record/squats_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Record::SquatsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get record_squats_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get record_squats_create_url
+    assert_response :success
+  end
+end

--- a/test/controllers/record/weigh_ins_controller_test.rb
+++ b/test/controllers/record/weigh_ins_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Record::WeighInsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get record_weigh_ins_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get record_weigh_ins_create_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/record/bench_presses.yml
+++ b/test/fixtures/record/bench_presses.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/record/comments.yml
+++ b/test/fixtures/record/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/record/deadlifts.yml
+++ b/test/fixtures/record/deadlifts.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/record/squats.yml
+++ b/test/fixtures/record/squats.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/record/weigh_ins.yml
+++ b/test/fixtures/record/weigh_ins.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/record/bench_press_test.rb
+++ b/test/models/record/bench_press_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Record::BenchPressTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/record/comment_test.rb
+++ b/test/models/record/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Record::CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/record/deadlift_test.rb
+++ b/test/models/record/deadlift_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Record::DeadliftTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/record/squat_test.rb
+++ b/test/models/record/squat_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Record::SquatTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/record/weigh_in_test.rb
+++ b/test/models/record/weigh_in_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Record::WeighInTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 変更の概要

* 変更の概要
  試技結果記録ページにて、20項目を１ページで表示していたが、
  ページを分割し、5ステップにわけて表示するように変更した。
  
  20項目の内訳：検量体重、各種目の3試技分の重量と判定結果(18項目)、コメント

* 関連するIssueやプルリクエスト
  close #34 

## なぜこの変更をするのか

* 変更をする理由
  20項目を１ページに表示してしまうと、ユーザーが自分の試技結果を入力するときに
  視線が散りやすく入力ミスを誘発してしまう恐れがあるため

  試技結果を入力するとき、ユーザーは試技結果が記載してある別のブラウザまたは手書きメモ
  などと本アプリのブラウザを行き来しながら入力すると想定。
  20項目が１ページに全てある状態だと、他画面からアプリの入力フォームに目線を戻したときに
  入力したいフォームがどこにあるのか探すはめになる。視線が散り、迷いやすい。

## やったこと

- [x] 試技結果記録を5ステップにわける

  ステップ1　検量体重
  ステップ2　スクワット
  ステップ3　ベンチプレス
  ステップ4　デッドリフト
  ステップ5　振り返りコメント

- [x] 各ステップ毎にバリデーションを検証させる。
  有効でないと次のステップにいけないようにする
  - [x] ステップ1
  検量体重は必須、数字で入力されているか
  - [x] ステップ2~3
  試技結果は、文字列を入力させない
  重量を入力したら、判定結果を成功か失敗か選択必須
  - [x] ステップ4
  コメントは、任意なのでバリデーションかけていません
 

  - [x] 各ステップのユーザー入力のパラメータはsessionに一時保存していく。
  - [x] 最終ステップでCompetition_recordsテーブルにレコードを一括保存する。 
  - [x] 最終ステップでレコードを一括保存したあとに、sessionに保存した値を消す。
  