### PR TITLE
fix: 試技結果を項目ごとに個別に編集可能に変更

### DIFF
--- a/app/controllers/competition_records_controller.rb
+++ b/app/controllers/competition_records_controller.rb
@@ -1,53 +1,13 @@
 class CompetitionRecordsController < ApplicationController
   before_action :set_competition
-  before_action :set_competition_record, only: %i[ edit update destroy ]
-  skip_before_action :set_bottom_navi, only: %i[ new edit ]
-
-  def new
-    @competition_record = CompetitionRecord.new
-  end
-
-  def create
-    @competition_record = CompetitionRecord.new(competition_record_params)
-    if @competition_record.save
-      redirect_to competition_path(@competition)
-    else
-      render :new, status: :unprocessable_entity
-    end
-  end
-
-  def edit; end
-
-  def update
-    if @competition_record.update(competition_record_params)
-      redirect_to competition_path(@competition)
-    else
-      render :edit, status: :unprocessable_entity
-    end
-  end
+  before_action :set_competition_record, only: %i[ destroy ]
 
   def destroy
     @competition_record.destroy!
-    redirect_to competitions_path
+    redirect_to competition_path(@competition)
   end
 
   private
-
-  def competition_record_params
-    params.require(:competition_record).permit(
-      :weight,
-      :squat_first_attempt, :squat_first_attempt_result,
-      :squat_second_attempt, :squat_second_attempt_result,
-      :squat_third_attempt, :squat_third_attempt_result,
-      :benchpress_first_attempt, :benchpress_first_attempt_result,
-      :benchpress_second_attempt, :benchpress_second_attempt_result,
-      :benchpress_third_attempt, :benchpress_third_attempt_result,
-      :deadlift_first_attempt, :deadlift_first_attempt_result,
-      :deadlift_second_attempt, :deadlift_second_attempt_result,
-      :deadlift_third_attempt, :deadlift_third_attempt_result,
-      :comment
-    ).merge(competition_id: params[:competition_id])
-  end
 
   def set_competition
     @competition = current_user.competitions.find(params[:competition_id])

--- a/app/controllers/record/bench_presses_controller.rb
+++ b/app/controllers/record/bench_presses_controller.rb
@@ -23,6 +23,44 @@ class Record::BenchPressesController < ApplicationController
     end
   end
 
+  def edit
+    # competitionのレコードを取得してくる
+    @competition = current_user.competitions.find(params[:competition_id])
+    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
+    @competition_record = @competition.competition_record
+    @bench_press = Record::BenchPress.new(
+      benchpress_first_attempt: @competition_record.benchpress_first_attempt,
+      benchpress_second_attempt: @competition_record.benchpress_second_attempt,
+      benchpress_third_attempt: @competition_record.benchpress_third_attempt,
+      benchpress_first_attempt_result: @competition_record.benchpress_first_attempt_result,
+      benchpress_second_attempt_result: @competition_record.benchpress_second_attempt_result,
+      benchpress_third_attempt_result: @competition_record.benchpress_third_attempt_result
+  )
+  end
+
+  def update
+    # ユーザーが入力した値を取得
+    @bench_press = Record::BenchPress.new(bench_press_params)
+    # competitionのレコードを取得してくる
+    @competition = current_user.competitions.find(params[:competition_id])
+    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
+    @competition_record = @competition.competition_record
+    bench_press_update_params = {
+      benchpress_first_attempt: @bench_press.benchpress_first_attempt,
+      benchpress_second_attempt: @bench_press.benchpress_second_attempt,
+      benchpress_third_attempt: @bench_press.benchpress_third_attempt,
+      benchpress_first_attempt_result: @bench_press.benchpress_first_attempt_result,
+      benchpress_second_attempt_result: @bench_press.benchpress_second_attempt_result,
+      benchpress_third_attempt_result: @bench_press.benchpress_third_attempt_result
+    }
+    # 取得したレコードの値を、ユーザーが入力してきた値に上書きしてupdateする
+    if @competition_record.update(bench_press_update_params)
+      redirect_to competition_path(@competition) # 成功したら詳細ページへ遷移する
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def bench_press_params

--- a/app/controllers/record/bench_presses_controller.rb
+++ b/app/controllers/record/bench_presses_controller.rb
@@ -1,13 +1,14 @@
 class Record::BenchPressesController < ApplicationController
+  before_action :set_competition
+  before_action :set_competition_record, only: %i[ edit update ]
   skip_before_action :set_bottom_navi, only: %i[ new edit ]
+
   def new
     @bench_press = Record::BenchPress.new
-    @competition = current_user.competitions.find(params[:competition_id])
   end
 
   def create
     @bench_press = Record::BenchPress.new(bench_press_params)
-    @competition = current_user.competitions.find(params[:competition_id])
     if @bench_press.valid? # 手動でバリデーションの検証をする
       session[:record].merge!({
         benchpress_first_attempt: @bench_press.benchpress_first_attempt,
@@ -24,10 +25,6 @@ class Record::BenchPressesController < ApplicationController
   end
 
   def edit
-    # competitionのレコードを取得してくる
-    @competition = current_user.competitions.find(params[:competition_id])
-    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
-    @competition_record = @competition.competition_record
     @bench_press = Record::BenchPress.new(
       benchpress_first_attempt: @competition_record.benchpress_first_attempt,
       benchpress_second_attempt: @competition_record.benchpress_second_attempt,
@@ -41,10 +38,6 @@ class Record::BenchPressesController < ApplicationController
   def update
     # ユーザーが入力した値を取得
     @bench_press = Record::BenchPress.new(bench_press_params)
-    # competitionのレコードを取得してくる
-    @competition = current_user.competitions.find(params[:competition_id])
-    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
-    @competition_record = @competition.competition_record
     bench_press_update_params = {
       benchpress_first_attempt: @bench_press.benchpress_first_attempt,
       benchpress_second_attempt: @bench_press.benchpress_second_attempt,
@@ -68,5 +61,13 @@ class Record::BenchPressesController < ApplicationController
     :benchpress_first_attempt, :benchpress_first_attempt_result,
     :benchpress_second_attempt, :benchpress_second_attempt_result,
     :benchpress_third_attempt, :benchpress_third_attempt_result)
+  end
+
+  def set_competition
+    @competition = current_user.competitions.find(params[:competition_id])
+  end
+
+  def set_competition_record
+    @competition_record = @competition.competition_record
   end
 end

--- a/app/controllers/record/comments_controller.rb
+++ b/app/controllers/record/comments_controller.rb
@@ -27,6 +27,29 @@ class Record::CommentsController < ApplicationController
     end
   end
 
+  def edit
+    # competitionのレコードを取得してくる
+    @competition = current_user.competitions.find(params[:competition_id])
+    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
+    @competition_record = @competition.competition_record
+    @comment = Record::Comment.new(comment: @competition_record.comment)
+  end
+
+  def update
+    # ユーザーが入力した値を取得
+    @comment = Record::Comment.new(comment_params)
+    # competitionのレコードを取得してくる
+    @competition = current_user.competitions.find(params[:competition_id])
+    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
+    @competition_record = @competition.competition_record
+    # 取得したレコードのweightの値を、@weigh_in.weightに上書きしてupdateする
+    if @competition_record.update(comment: @comment.comment)
+      redirect_to competition_path(@competition) # 成功したら詳細ページへ遷移する
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def comment_params

--- a/app/controllers/record/comments_controller.rb
+++ b/app/controllers/record/comments_controller.rb
@@ -1,14 +1,14 @@
 class Record::CommentsController < ApplicationController
+  before_action :set_competition
+  before_action :set_competition_record, only: %i[ edit update ]
   skip_before_action :set_bottom_navi, only: %i[ new edit ]
 
   def new
     @comment = Record::Comment.new
-    @competition = current_user.competitions.find(params[:competition_id])
   end
 
   def create
     @comment = Record::Comment.new(comment_params)
-    @competition = current_user.competitions.find(params[:competition_id])
     if @comment.valid? # 手動でバリデーションの検証をする
       # @commentを、sessionに保存
       session[:record].merge!({
@@ -28,20 +28,12 @@ class Record::CommentsController < ApplicationController
   end
 
   def edit
-    # competitionのレコードを取得してくる
-    @competition = current_user.competitions.find(params[:competition_id])
-    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
-    @competition_record = @competition.competition_record
     @comment = Record::Comment.new(comment: @competition_record.comment)
   end
 
   def update
     # ユーザーが入力した値を取得
     @comment = Record::Comment.new(comment_params)
-    # competitionのレコードを取得してくる
-    @competition = current_user.competitions.find(params[:competition_id])
-    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
-    @competition_record = @competition.competition_record
     # 取得したレコードのweightの値を、@weigh_in.weightに上書きしてupdateする
     if @competition_record.update(comment: @comment.comment)
       redirect_to competition_path(@competition) # 成功したら詳細ページへ遷移する
@@ -54,5 +46,13 @@ class Record::CommentsController < ApplicationController
 
   def comment_params
     params.require(:record_comment).permit(:comment)
+  end
+
+  def set_competition
+    @competition = current_user.competitions.find(params[:competition_id])
+  end
+
+  def set_competition_record
+    @competition_record = @competition.competition_record
   end
 end

--- a/app/controllers/record/deadlifts_controller.rb
+++ b/app/controllers/record/deadlifts_controller.rb
@@ -24,6 +24,44 @@ class Record::DeadliftsController < ApplicationController
     end
   end
 
+  def edit
+    # competitionのレコードを取得してくる
+    @competition = current_user.competitions.find(params[:competition_id])
+    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
+    @competition_record = @competition.competition_record
+    @deadlift = Record::Deadlift.new(
+      deadlift_first_attempt: @competition_record.deadlift_first_attempt,
+      deadlift_second_attempt: @competition_record.deadlift_second_attempt,
+      deadlift_third_attempt: @competition_record.deadlift_third_attempt,
+      deadlift_first_attempt_result: @competition_record.deadlift_first_attempt_result,
+      deadlift_second_attempt_result: @competition_record.deadlift_second_attempt_result,
+      deadlift_third_attempt_result: @competition_record.deadlift_third_attempt_result
+    )
+  end
+
+  def update
+    # ユーザーが入力した値を取得
+    @deadlift = Record::Deadlift.new(deadlift_params)
+    # competitionのレコードを取得してくる
+    @competition = current_user.competitions.find(params[:competition_id])
+    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
+    @competition_record = @competition.competition_record
+    deadlift_update_params = {
+      deadlift_first_attempt: @deadlift.deadlift_first_attempt,
+      deadlift_second_attempt: @deadlift.deadlift_second_attempt,
+      deadlift_third_attempt: @deadlift.deadlift_third_attempt,
+      deadlift_first_attempt_result: @deadlift.deadlift_first_attempt_result,
+      deadlift_second_attempt_result: @deadlift.deadlift_second_attempt_result,
+      deadlift_third_attempt_result: @deadlift.deadlift_third_attempt_result
+    }
+    # 取得したレコードの値を、ユーザーが入力してきた値に上書きしてupdateする
+    if @competition_record.update(deadlift_update_params)
+      redirect_to competition_path(@competition) # 成功したら詳細ページへ遷移する
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def deadlift_params

--- a/app/controllers/record/deadlifts_controller.rb
+++ b/app/controllers/record/deadlifts_controller.rb
@@ -1,14 +1,14 @@
 class Record::DeadliftsController < ApplicationController
+  before_action :set_competition
+  before_action :set_competition_record, only: %i[ edit update ]
   skip_before_action :set_bottom_navi, only: %i[ new edit ]
 
   def new
     @deadlift = Record::Deadlift.new
-    @competition = current_user.competitions.find(params[:competition_id])
   end
 
   def create
     @deadlift = Record::Deadlift.new(deadlift_params)
-    @competition = current_user.competitions.find(params[:competition_id])
     if @deadlift.valid? # 手動でバリデーションの検証をする
       session[:record].merge!({
         deadlift_first_attempt: @deadlift.deadlift_first_attempt,
@@ -25,10 +25,6 @@ class Record::DeadliftsController < ApplicationController
   end
 
   def edit
-    # competitionのレコードを取得してくる
-    @competition = current_user.competitions.find(params[:competition_id])
-    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
-    @competition_record = @competition.competition_record
     @deadlift = Record::Deadlift.new(
       deadlift_first_attempt: @competition_record.deadlift_first_attempt,
       deadlift_second_attempt: @competition_record.deadlift_second_attempt,
@@ -42,10 +38,6 @@ class Record::DeadliftsController < ApplicationController
   def update
     # ユーザーが入力した値を取得
     @deadlift = Record::Deadlift.new(deadlift_params)
-    # competitionのレコードを取得してくる
-    @competition = current_user.competitions.find(params[:competition_id])
-    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
-    @competition_record = @competition.competition_record
     deadlift_update_params = {
       deadlift_first_attempt: @deadlift.deadlift_first_attempt,
       deadlift_second_attempt: @deadlift.deadlift_second_attempt,
@@ -69,5 +61,13 @@ class Record::DeadliftsController < ApplicationController
     :deadlift_first_attempt, :deadlift_first_attempt_result,
     :deadlift_second_attempt, :deadlift_second_attempt_result,
     :deadlift_third_attempt, :deadlift_third_attempt_result)
+  end
+
+  def set_competition
+    @competition = current_user.competitions.find(params[:competition_id])
+  end
+
+  def set_competition_record
+    @competition_record = @competition.competition_record
   end
 end

--- a/app/controllers/record/squats_controller.rb
+++ b/app/controllers/record/squats_controller.rb
@@ -1,14 +1,14 @@
 class Record::SquatsController < ApplicationController
-skip_before_action :set_bottom_navi, only: %i[ new edit ]
+  before_action :set_competition
+  before_action :set_competition_record, only: %i[ edit update ]
+  skip_before_action :set_bottom_navi, only: %i[ new edit ]
 
   def new
     @squat = Record::Squat.new
-    @competition = current_user.competitions.find(params[:competition_id])
   end
 
   def create
     @squat = Record::Squat.new(squat_params)
-    @competition = current_user.competitions.find(params[:competition_id])
     if @squat.valid? # 手動でバリデーションの検証をする
       session[:record].merge!({
         squat_first_attempt: @squat.squat_first_attempt,
@@ -25,10 +25,6 @@ skip_before_action :set_bottom_navi, only: %i[ new edit ]
   end
 
   def edit
-    # competitionのレコードを取得してくる
-    @competition = current_user.competitions.find(params[:competition_id])
-    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
-    @competition_record = @competition.competition_record
     @squat = Record::Squat.new(
 		squat_first_attempt: @competition_record.squat_first_attempt,
     squat_second_attempt: @competition_record.squat_second_attempt,
@@ -42,10 +38,6 @@ skip_before_action :set_bottom_navi, only: %i[ new edit ]
   def update
     # ユーザーが入力した値を取得
     @squat = Record::Squat.new(squat_params)
-    # competitionのレコードを取得してくる
-    @competition = current_user.competitions.find(params[:competition_id])
-    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
-    @competition_record = @competition.competition_record
     squat_update_params = {
       squat_first_attempt: @squat.squat_first_attempt,
       squat_second_attempt: @squat.squat_second_attempt,
@@ -69,6 +61,14 @@ skip_before_action :set_bottom_navi, only: %i[ new edit ]
     :squat_first_attempt, :squat_first_attempt_result,
     :squat_second_attempt, :squat_second_attempt_result,
     :squat_third_attempt, :squat_third_attempt_result)
+  end
+
+  def set_competition
+    @competition = current_user.competitions.find(params[:competition_id])
+  end
+
+  def set_competition_record
+    @competition_record = @competition.competition_record
   end
 end
 

--- a/app/controllers/record/squats_controller.rb
+++ b/app/controllers/record/squats_controller.rb
@@ -24,6 +24,44 @@ skip_before_action :set_bottom_navi, only: %i[ new edit ]
     end
   end
 
+  def edit
+    # competitionのレコードを取得してくる
+    @competition = current_user.competitions.find(params[:competition_id])
+    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
+    @competition_record = @competition.competition_record
+    @squat = Record::Squat.new(
+		squat_first_attempt: @competition_record.squat_first_attempt,
+    squat_second_attempt: @competition_record.squat_second_attempt,
+    squat_third_attempt: @competition_record.squat_third_attempt,
+    squat_first_attempt_result: @competition_record.squat_first_attempt_result,
+    squat_second_attempt_result: @competition_record.squat_second_attempt_result,
+    squat_third_attempt_result: @competition_record.squat_third_attempt_result
+  )
+	end
+
+  def update
+    # ユーザーが入力した値を取得
+    @squat = Record::Squat.new(squat_params)
+    # competitionのレコードを取得してくる
+    @competition = current_user.competitions.find(params[:competition_id])
+    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
+    @competition_record = @competition.competition_record
+    squat_update_params = {
+      squat_first_attempt: @squat.squat_first_attempt,
+      squat_second_attempt: @squat.squat_second_attempt,
+      squat_third_attempt: @squat.squat_third_attempt,
+      squat_first_attempt_result: @squat.squat_first_attempt_result,
+      squat_second_attempt_result: @squat.squat_second_attempt_result,
+      squat_third_attempt_result: @squat.squat_third_attempt_result
+    }
+    # 取得したレコードの値を、ユーザーが入力してきた値に上書きしてupdateする
+    if @competition_record.update(squat_update_params)
+      redirect_to competition_path(@competition) # 成功したら詳細ページへ遷移する
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def squat_params
@@ -33,3 +71,4 @@ skip_before_action :set_bottom_navi, only: %i[ new edit ]
     :squat_third_attempt, :squat_third_attempt_result)
   end
 end
+

--- a/app/controllers/record/weigh_ins_controller.rb
+++ b/app/controllers/record/weigh_ins_controller.rb
@@ -20,6 +20,30 @@ class Record::WeighInsController < ApplicationController
     end
   end
 
+  def edit
+    # competitionのレコードを取得してくる
+    @competition = current_user.competitions.find(params[:competition_id])
+    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
+    @competition_record = @competition.competition_record
+    # Record::WeighInモデルのインスタンスを生成し、属性にweightの値をいれる
+    @weigh_in = Record::WeighIn.new(weight: @competition_record.weight)
+  end
+
+  def update
+    # ユーザーが入力した値を取得
+    @weigh_in = Record::WeighIn.new(weigh_in_params)
+    # competitionのレコードを取得してくる
+    @competition = current_user.competitions.find(params[:competition_id])
+    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
+    @competition_record = @competition.competition_record
+    # 取得したレコードのweightの値を、@weigh_in.weightに上書きしてupdateする
+    if @competition_record.update(weight: @weigh_in.weight)
+      redirect_to competition_path(@competition) # 成功したら詳細ページへ遷移する
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def weigh_in_params

--- a/app/controllers/record/weigh_ins_controller.rb
+++ b/app/controllers/record/weigh_ins_controller.rb
@@ -1,14 +1,14 @@
 class Record::WeighInsController < ApplicationController
+  before_action :set_competition
+  before_action :set_competition_record, only: %i[ edit update ]
   skip_before_action :set_bottom_navi, only: %i[ new edit ]
 
   def new
     @weigh_in = Record::WeighIn.new
-    @competition = current_user.competitions.find(params[:competition_id])
   end
 
   def create
     @weigh_in = Record::WeighIn.new(weigh_in_params)
-    @competition = current_user.competitions.find(params[:competition_id])
     if @weigh_in.valid? # 手動でバリデーションの検証をする
       session[:record] = {
         competition_id: @weigh_in.competition_id,
@@ -21,21 +21,12 @@ class Record::WeighInsController < ApplicationController
   end
 
   def edit
-    # competitionのレコードを取得してくる
-    @competition = current_user.competitions.find(params[:competition_id])
-    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
-    @competition_record = @competition.competition_record
-    # Record::WeighInモデルのインスタンスを生成し、属性にweightの値をいれる
     @weigh_in = Record::WeighIn.new(weight: @competition_record.weight)
   end
 
   def update
     # ユーザーが入力した値を取得
     @weigh_in = Record::WeighIn.new(weigh_in_params)
-    # competitionのレコードを取得してくる
-    @competition = current_user.competitions.find(params[:competition_id])
-    # 取得したcompetitionのレコードに紐づくcompetition_recordレコードを取得
-    @competition_record = @competition.competition_record
     # 取得したレコードのweightの値を、@weigh_in.weightに上書きしてupdateする
     if @competition_record.update(weight: @weigh_in.weight)
       redirect_to competition_path(@competition) # 成功したら詳細ページへ遷移する
@@ -48,5 +39,13 @@ class Record::WeighInsController < ApplicationController
 
   def weigh_in_params
     params.require(:record_weigh_in).permit(:weight).merge(competition_id: params[:competition_id])
+  end
+
+  def set_competition
+    @competition = current_user.competitions.find(params[:competition_id])
+  end
+
+  def set_competition_record
+    @competition_record = @competition.competition_record
   end
 end

--- a/app/views/competition_records/_competition_record.html.erb
+++ b/app/views/competition_records/_competition_record.html.erb
@@ -12,6 +12,7 @@
   <!-- SQ試技結果 -->
   <div class="border-b-2 border-dashed py-2">
     <h2 class="font-bold pb-1">スクワット</h2>
+    <%= link_to "編集", edit_competition_squat_path(@competition), class: "btn btn-sm btn-primary max-w-24 mx-2" %>
     <!-- SQ第１試技 -->
     <div class="flex flex-row pb-1">
       <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
@@ -61,6 +62,7 @@
   <!-- BP試技結果 -->
   <div class="border-b-2 border-dashed py-2">
     <h2 class="font-bold pb-1">ベンチプレス</h2>
+    <%= link_to "編集", edit_competition_bench_presse_path(@competition), class: "btn btn-sm btn-primary max-w-24 mx-2" %>
     <!-- BP第１試技 -->
     <div class="flex flex-row pb-1">
       <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
@@ -110,6 +112,7 @@
   <!-- DL試技結果 -->
   <div class="border-b-2 border-dashed py-2">
     <h2 class="font-bold pb-1">デッドリフト</h2>
+    <%= link_to "編集", edit_competition_deadlift_path(@competition), class: "btn btn-sm btn-primary max-w-24 mx-2" %>
     <!-- DL第１試技 -->
     <div class="flex flex-row pb-1">
       <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
@@ -159,6 +162,7 @@
   <!-- コメント -->
   <div class="border-b-2 border-dashed py-2">
     <h2 class="font-bold pb-1">コメント</h2>
+    <%= link_to "編集", edit_competition_comment_path(@competition), class: "btn btn-sm btn-primary max-w-24 mx-2" %>
     <!-- 振り返りコメント -->
     <div class="rounded border border-gray-400 text-sm">
       <%= simple_format(h(competition_record.comment)) %>

--- a/app/views/competition_records/_competition_record.html.erb
+++ b/app/views/competition_records/_competition_record.html.erb
@@ -7,6 +7,7 @@
   <div class="border-b-2 border-dashed py-2">
     <h2 class="font-bold"><%= CompetitionRecord.human_attribute_name(:weight) %>:</h2>
     <p class="text-sm"> <%= competition_record.weight %> kg</p>
+    <%= link_to "編集", edit_competition_weigh_in_path(@competition), class: "btn btn-sm btn-primary max-w-24 mx-2" %>
   </div>
   <!-- SQ試技結果 -->
   <div class="border-b-2 border-dashed py-2">
@@ -101,7 +102,7 @@
         <p class="text-sm basis-1/3 text-right text-red-500">
       <% elsif competition_record.benchpress_third_not_attempted? %>
         <p class="text-sm basis-1/3 text-right text-gray-500">
-      <% end %> 
+      <% end %>
         <%= competition_record.benchpress_third_attempt_result_i18n %>
       </p>
     </div>

--- a/app/views/competition_records/_competition_record.html.erb
+++ b/app/views/competition_records/_competition_record.html.erb
@@ -199,6 +199,6 @@
     </div>
   </div>
   <div class="flex justify-end w-full">
-    <%= link_to "削除", '#', data: {turbo_method: :delete, turbo_confirm: "削除しますか？"}, class: "btn btn-sm btn-error max-w-24" %>
+    <%= link_to "削除", competition_competition_record_path(@competition), data: {turbo_method: :delete, turbo_confirm: "削除しますか？"}, class: "btn btn-sm btn-error max-w-24" %>
   </div>
 </div>

--- a/app/views/competition_records/_competition_record.html.erb
+++ b/app/views/competition_records/_competition_record.html.erb
@@ -5,14 +5,26 @@
     </h1>
   </div>
   <div class="border-b-2 border-dashed py-2">
-    <h2 class="font-bold"><%= CompetitionRecord.human_attribute_name(:weight) %>:</h2>
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="font-bold mr-2">検量体重</h2>
+      <%= link_to edit_competition_weigh_in_path(@competition), class: "flex items-center" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="h-5 w-5" fill="#fda4af" > <!-- アイコンの大きさを設定 -->
+          <path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z"/>
+        </svg>
+      <% end %>
+    </div>
     <p class="text-sm"> <%= competition_record.weight %> kg</p>
-    <%= link_to "編集", edit_competition_weigh_in_path(@competition), class: "btn btn-sm btn-primary max-w-24 mx-2" %>
   </div>
   <!-- SQ試技結果 -->
   <div class="border-b-2 border-dashed py-2">
-    <h2 class="font-bold pb-1">スクワット</h2>
-    <%= link_to "編集", edit_competition_squat_path(@competition), class: "btn btn-sm btn-primary max-w-24 mx-2" %>
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="font-bold mr-2">スクワット</h2>
+      <%= link_to edit_competition_squat_path(@competition), class: "flex items-center" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="h-5 w-5" fill="#fda4af" > <!-- アイコンの大きさを設定 -->
+          <path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z"/>
+        </svg>
+      <% end %>
+    </div>
     <!-- SQ第１試技 -->
     <div class="flex flex-row pb-1">
       <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
@@ -61,8 +73,14 @@
   </div>
   <!-- BP試技結果 -->
   <div class="border-b-2 border-dashed py-2">
-    <h2 class="font-bold pb-1">ベンチプレス</h2>
-    <%= link_to "編集", edit_competition_bench_presse_path(@competition), class: "btn btn-sm btn-primary max-w-24 mx-2" %>
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="font-bold mr-2">ベンチプレス</h2>
+      <%= link_to edit_competition_bench_presse_path(@competition), class: "flex items-center" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="h-5 w-5" fill="#fda4af" > <!-- アイコンの大きさを設定 -->
+          <path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z"/>
+        </svg>
+      <% end %>
+    </div>
     <!-- BP第１試技 -->
     <div class="flex flex-row pb-1">
       <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
@@ -111,8 +129,14 @@
   </div>
   <!-- DL試技結果 -->
   <div class="border-b-2 border-dashed py-2">
-    <h2 class="font-bold pb-1">デッドリフト</h2>
-    <%= link_to "編集", edit_competition_deadlift_path(@competition), class: "btn btn-sm btn-primary max-w-24 mx-2" %>
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="font-bold mr-2">デッドリフト</h2>
+      <%= link_to edit_competition_deadlift_path(@competition), class: "flex items-center" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="h-5 w-5" fill="#fda4af" > <!-- アイコンの大きさを設定 -->
+          <path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z"/>
+        </svg>
+      <% end %>
+    </div>
     <!-- DL第１試技 -->
     <div class="flex flex-row pb-1">
       <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
@@ -161,15 +185,20 @@
   </div>
   <!-- コメント -->
   <div class="border-b-2 border-dashed py-2">
-    <h2 class="font-bold pb-1">コメント</h2>
-    <%= link_to "編集", edit_competition_comment_path(@competition), class: "btn btn-sm btn-primary max-w-24 mx-2" %>
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="font-bold mr-2">コメント</h2>
+      <%= link_to edit_competition_comment_path(@competition), class: "flex items-center" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="h-5 w-5" fill="#fda4af" > <!-- アイコンの大きさを設定 -->
+          <path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z"/>
+        </svg>
+      <% end %>
+    </div>
     <!-- 振り返りコメント -->
     <div class="rounded border border-gray-400 text-sm">
       <%= simple_format(h(competition_record.comment)) %>
     </div>
   </div>
   <div class="flex justify-end w-full">
-    <%= link_to "編集", '#', class: "btn btn-sm btn-primary max-w-24 mx-2" %>
     <%= link_to "削除", '#', data: {turbo_method: :delete, turbo_confirm: "削除しますか？"}, class: "btn btn-sm btn-error max-w-24" %>
   </div>
 </div>

--- a/app/views/record/bench_presses/edit.html.erb
+++ b/app/views/record/bench_presses/edit.html.erb
@@ -1,0 +1,119 @@
+<div class="hero min-h-screen bg-white">
+  <div class="hero-content flex-col">
+    <div class="items-center mx-auto max-w-80 min-w-80">
+      <h1 class="text-2xl text-center mb-5">ベンチプレス結果 編集</h1>
+			<%= form_with model: @bench_press, url: competition_bench_presse_path(@competition), method: "patch" do |f| %>
+				<!-- ベンチプレス試技結果 -->
+				<!-- ベンチプレス第１試技 -->
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :benchpress_first_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_first_attempt %>
+					</div>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_first_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_first_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_first_attempt_result %>
+					</div>
+				</div>
+				<!-- ベンチプレス第2試技 -->
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :benchpress_second_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_second_attempt %>
+					</div>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_second_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_second_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_second_attempt_result %>
+					</div>
+				</div>
+				<!-- ベンチプレス第3試技 -->
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :benchpress_third_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_third_attempt %>
+					</div>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_third_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :benchpress_third_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_third_attempt_result %>
+					</div>
+				</div>
+				<!-- ボタン -->
+				<div class="form-control mt-6 flex flex-row justify-center">
+					<div>
+						<%= f.submit "更新", class: 'btn btn-secondary btn-sm w-24' %>
+					</div>
+				</div>
+			<% end %>
+      <!-- ここまでform_withを使う形に修正 -->
+    </div>
+  </div>
+</div>

--- a/app/views/record/comments/edit.html.erb
+++ b/app/views/record/comments/edit.html.erb
@@ -1,0 +1,22 @@
+<div class="hero min-h-screen bg-white">
+  <div class="hero-content flex-col">
+    <div class="items-center mx-auto max-w-80 min-w-80">
+      <h1 class="text-2xl text-center mb-5">振り返りコメント 編集</h1>
+			  <%= form_with model: @comment, url: competition_comment_path(@competition), method: "patch" do |f| %>
+          <!-- 振り返りコメント -->
+          <label class="form-control mb-6">
+            <div class="label p-0 flex justify-start items-center">
+              <p class="text-slate-500">(任意)</p>
+            </div>
+              <%= f.text_area :comment, class:"textarea textarea-bordered h-80" %>
+          </label>
+          <!-- ボタン -->
+          <div class="form-control mt-6 flex flex-row justify-center">
+            <div>
+              <%= f.submit "更新", class: 'btn btn-secondary btn-sm w-24' %>
+            </div>
+				  </div>
+        <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/record/deadlifts/edit.html.erb
+++ b/app/views/record/deadlifts/edit.html.erb
@@ -1,0 +1,119 @@
+<div class="hero min-h-screen bg-white">
+  <div class="hero-content flex-col">
+    <div class="items-center mx-auto max-w-80 min-w-80">
+      <h1 class="text-2xl text-center mb-5">デッドリフト結果 編集</h1>
+			<%= form_with model: @deadlift, url: competition_deadlift_path(@competition), method: "patch" do |f| %>
+				<!-- デッドリフト試技結果 -->
+				<!-- デッドリフト第１試技 -->
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :deadlift_first_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_first_attempt %>
+					</div>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_first_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_first_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_first_attempt_result %>
+					</div>
+				</div>
+				<!-- デッドリフト第2試技 -->
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :deadlift_second_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_second_attempt %>
+					</div>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_second_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_second_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_second_attempt_result %>
+					</div>
+				</div>
+				<!-- デッドリフト第3試技 -->
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :deadlift_third_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_third_attempt %>
+					</div>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_third_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :deadlift_third_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_third_attempt_result %>
+					</div>
+				</div>
+				<!-- ボタン -->
+				<div class="form-control mt-6 flex flex-row justify-center">
+					<div>
+						<%= f.submit "更新", class: 'btn btn-secondary btn-sm w-24' %>
+					</div>
+				</div>
+			<% end %>
+      <!-- ここまでform_withを使う形に修正 -->
+    </div>
+  </div>
+</div>

--- a/app/views/record/squats/edit.html.erb
+++ b/app/views/record/squats/edit.html.erb
@@ -1,0 +1,119 @@
+<div class="hero min-h-screen bg-white">
+  <div class="hero-content flex-col">
+    <div class="items-center mx-auto max-w-80 min-w-80">
+      <h1 class="text-2xl text-center mb-5">スクワット結果登録</h1>
+			<%= form_with model: @squat, url: competition_squat_path(@competition), method: "patch" do |f| %>
+				<!-- スクワット試技結果 -->
+				<!-- スクワット第１試技 -->
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :squat_first_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :squat_first_attempt %>
+					</div>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :squat_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_first_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :squat_first_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_first_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :squat_first_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_first_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :squat_first_attempt_result %>
+					</div>
+				</div>
+				<!-- スクワット第2試技 -->
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :squat_second_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :squat_second_attempt %>
+					</div>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :squat_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_second_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :squat_second_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_second_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :squat_second_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_second_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :squat_second_attempt_result %>
+					</div>
+				</div>
+				<!-- スクワット第3試技 -->
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<!-- 重量-->
+					<div class="flex flex-col mb-3">
+						<div class="flex justify-between">
+							<%= f.label :squat_third_attempt, class: 'text-xl' %>
+							<label class="form-control flex flex-row">
+								<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<span>kg</span>
+							</label>
+						</div>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :squat_third_attempt %>
+					</div>
+					<!--判定-->
+					<div class="flex flex-col mb-3">
+						<label class="form-control">
+								<div class="flex justify-between items-center mt-2">
+										<label class="flex items-center">
+												<%= f.radio_button :squat_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_third_attempt_result, "未試行" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :squat_third_attempt_result, 'success', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_third_attempt_result, "成功" %></span>
+										</label>
+										<label class="flex items-center">
+												<%= f.radio_button :squat_third_attempt_result, 'failure', class: 'radio radio-primary' %>
+												<span class="ml-2"><%= f.label :squat_third_attempt_result, "失敗" %></span>
+										</label>
+								</div>
+						</label>
+						<%= render 'shared/error_messages', object: @competition_record, attribute: :squat_third_attempt_result %>
+					</div>
+				</div>
+				<!-- ボタン -->
+				<div class="form-control mt-6 flex flex-row justify-center">
+					<div>
+						<%= f.submit "更新", class: 'btn btn-secondary btn-sm w-24' %>
+					</div>
+				</div>
+			<% end %>
+      <!-- ここまでform_withを使う形に修正 -->
+    </div>
+  </div>
+</div>

--- a/app/views/record/weigh_ins/edit.html.erb
+++ b/app/views/record/weigh_ins/edit.html.erb
@@ -1,0 +1,29 @@
+<div class="hero min-h-screen bg-white">
+  <div class="hero-content flex-col">
+    <div class="items-center mx-auto max-w-80 min-w-80">
+      <h1 class="text-2xl text-center mb-5">検量体重　編集</h1>
+			<%= form_with model: @weigh_in, url: competition_weigh_in_path(@competition), method: "patch" do |f| %>
+				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+					<div class="flex justify-between">
+						<div class="label p-0 flex justify-start items-center">
+							<%= f.label :weight, class: 'mr-2'%>
+							<p class="text-red-500">(必須)</p>
+						</div>
+						<label class="form-control flex flex-row">
+							<%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder:"検量体重"%>
+							<span>kg</span>
+						</label>
+					</div>
+					<%= render 'shared/error_messages', object: @competition_record, attribute: :weight %>
+				</div>
+			<!-- ボタン -->
+			<div class="form-control mt-6 flex flex-row justify-center">
+				<div>
+					<%= f.submit "更新", class: 'btn btn-secondary btn-sm w-24' %>
+				</div>
+			</div>
+			<% end %>
+    </div>
+  </div>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,11 +9,11 @@ Rails.application.routes.draw do
     resource :competition_record, only: [:destroy]
     scope module: 'record' do
       # 各ステップのルーティング
-      resource :weigh_in, only: [:new, :create]
-      resource :squat, only: [:new, :create]
-      resource :bench_presse, only: [:new, :create]
-      resource :deadlift, only: [:new, :create]
-      resource :comment, only: [:new, :create]
+      resource :weigh_in, only: [:new, :create, :edit, :update]
+      resource :squat, only: [:new, :create, :edit, :update]
+      resource :bench_presse, only: [:new, :create, :edit, :update]
+      resource :deadlift, only: [:new, :create, :edit, :update]
+      resource :comment, only: [:new, :create, :edit, :update]
     end
   end
   # Defines the root path route ("/")


### PR DESCRIPTION
## 変更の概要

**変更前:**  
試技結果はすべてのカラムを一括で修正
**変更後:**
試技結果を以下の項目ごとに個別に編集可能に変更

  - 検量体重
  - スクワット試技結果
  - ベンチプレス試技結果
  - デッドリフト試技結果
  - コメント

* 関連するIssueやプルリクエスト
  close #157 

## なぜこの変更をするのか
* 試技結果の登録をステップ入力化した理由と同様
* 編集するときは、ユーザーが入力ミスを修正したいときと想定
  一括編集だと、画面の入力フォーム項目数が多くて見にくいし、操作性悪い
  修正したい箇所の項目だけを編集可能にすることでそれらの懸念点を解消。
