### PR TITLE
add: 試技結果ステップ入力時、試技結果詳細ページ、パワーリフティングかシングルベンチかで表示内容切り替え

### DIFF
--- a/app/controllers/record/bench_presses_controller.rb
+++ b/app/controllers/record/bench_presses_controller.rb
@@ -18,7 +18,12 @@ class Record::BenchPressesController < ApplicationController
         benchpress_second_attempt_result: @bench_press.benchpress_second_attempt_result,
         benchpress_third_attempt_result: @bench_press.benchpress_third_attempt_result
       })
-      redirect_to  new_competition_deadlift_path # 次のステップへ遷移
+      case @competition.category
+        when "パワーリフティング"
+          redirect_to new_competition_deadlift_path # デッドリフトへ
+        when "シングルベンチプレス"
+          redirect_to new_competition_comment_path # コメントへ
+      end
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/record/weigh_ins_controller.rb
+++ b/app/controllers/record/weigh_ins_controller.rb
@@ -14,7 +14,12 @@ class Record::WeighInsController < ApplicationController
         competition_id: @weigh_in.competition_id,
         weight: @weigh_in.weight
       }
-      redirect_to new_competition_squat_path # 次のステップへ遷移
+      case @competition.category
+        when "パワーリフティング"
+          redirect_to new_competition_squat_path # スクワットへ
+        when "シングルベンチプレス"
+          redirect_to new_competition_bench_presse_path # ベンチプレスへ
+      end
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/views/competition_records/_competition_record.html.erb
+++ b/app/views/competition_records/_competition_record.html.erb
@@ -16,61 +16,63 @@
     <p class="text-sm"> <%= competition_record.weight %> kg</p>
   </div>
   <!-- SQ試技結果 -->
-  <div class="border-b-2 border-dashed py-2">
-    <div class="flex items-center justify-between mb-3">
-      <h2 class="font-bold mr-2">スクワット</h2>
-      <%= link_to edit_competition_squat_path(@competition), class: "flex items-center" do %>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="h-5 w-5" fill="#fda4af" > <!-- アイコンの大きさを設定 -->
-          <path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z"/>
-        </svg>
-      <% end %>
+  <% unless @competition.category == "シングルベンチプレス" %>
+    <div class="border-b-2 border-dashed py-2">
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="font-bold mr-2">スクワット</h2>
+        <%= link_to edit_competition_squat_path(@competition), class: "flex items-center" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="h-5 w-5" fill="#fda4af" > <!-- アイコンの大きさを設定 -->
+            <path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z"/>
+          </svg>
+        <% end %>
+      </div>
+      <!-- SQ第１試技 -->
+      <div class="flex flex-row pb-1">
+        <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
+        <p class="text-sm basis-1/3 text-right"> <%= competition_record.squat_first_attempt %> kg</p>
+        <!-- 判定結果 -->
+        <% if competition_record.squat_first_success? %>
+          <p class="text-sm basis-1/3 text-right text-green-500">
+        <% elsif competition_record.squat_first_failure? %>
+          <p class="text-sm basis-1/3 text-right text-red-500">
+        <% elsif competition_record.squat_first_not_attempted? %>
+          <p class="text-sm basis-1/3 text-right text-gray-500">
+        <% end %>
+          <%= competition_record.squat_first_attempt_result_i18n %>
+        </p>
+      </div>
+      <!-- SQ第2試技 -->
+      <div class="flex flex-row pb-1">
+        <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.second_attempt') %> </h3>
+        <p class="text-sm basis-1/3 text-right"> <%= competition_record.squat_second_attempt %> kg</p>
+        <!-- 判定結果 -->
+        <% if competition_record.squat_second_success? %>
+          <p class="text-sm basis-1/3 text-right text-green-500">
+        <% elsif competition_record.squat_second_failure? %>
+          <p class="text-sm basis-1/3 text-right text-red-500">
+        <% elsif competition_record.squat_second_not_attempted? %>
+          <p class="text-sm basis-1/3 text-right text-gray-500">
+        <% end %>
+          <%= competition_record.squat_second_attempt_result_i18n %>
+        </p>
+      </div>
+      <!-- SQ第3試技 -->
+      <div class="flex flex-row pb-1">
+        <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.third_attempt') %> </h3>
+        <p class="text-sm basis-1/3 text-right"> <%= competition_record.squat_third_attempt %> kg</p>
+        <!-- 判定結果 -->
+        <% if competition_record.squat_third_success? %>
+          <p class="text-sm basis-1/3 text-right text-green-500">
+        <% elsif competition_record.squat_third_failure? %>
+          <p class="text-sm basis-1/3 text-right text-red-500">
+        <% elsif competition_record.squat_third_not_attempted? %>
+          <p class="text-sm basis-1/3 text-right text-gray-500">
+        <% end %>
+          <%= competition_record.squat_third_attempt_result_i18n %>
+        </p>
+      </div>
     </div>
-    <!-- SQ第１試技 -->
-    <div class="flex flex-row pb-1">
-      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
-      <p class="text-sm basis-1/3 text-right"> <%= competition_record.squat_first_attempt %> kg</p>
-      <!-- 判定結果 -->
-      <% if competition_record.squat_first_success? %>
-        <p class="text-sm basis-1/3 text-right text-green-500">
-      <% elsif competition_record.squat_first_failure? %>
-        <p class="text-sm basis-1/3 text-right text-red-500">
-      <% elsif competition_record.squat_first_not_attempted? %>
-        <p class="text-sm basis-1/3 text-right text-gray-500">
-      <% end %>
-        <%= competition_record.squat_first_attempt_result_i18n %>
-      </p>
-    </div>
-    <!-- SQ第2試技 -->
-    <div class="flex flex-row pb-1">
-      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.second_attempt') %> </h3>
-      <p class="text-sm basis-1/3 text-right"> <%= competition_record.squat_second_attempt %> kg</p>
-      <!-- 判定結果 -->
-      <% if competition_record.squat_second_success? %>
-        <p class="text-sm basis-1/3 text-right text-green-500">
-      <% elsif competition_record.squat_second_failure? %>
-        <p class="text-sm basis-1/3 text-right text-red-500">
-      <% elsif competition_record.squat_second_not_attempted? %>
-        <p class="text-sm basis-1/3 text-right text-gray-500">
-      <% end %>
-        <%= competition_record.squat_second_attempt_result_i18n %>
-      </p>
-    </div>
-    <!-- SQ第3試技 -->
-    <div class="flex flex-row pb-1">
-      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.third_attempt') %> </h3>
-      <p class="text-sm basis-1/3 text-right"> <%= competition_record.squat_third_attempt %> kg</p>
-      <!-- 判定結果 -->
-      <% if competition_record.squat_third_success? %>
-        <p class="text-sm basis-1/3 text-right text-green-500">
-      <% elsif competition_record.squat_third_failure? %>
-        <p class="text-sm basis-1/3 text-right text-red-500">
-      <% elsif competition_record.squat_third_not_attempted? %>
-        <p class="text-sm basis-1/3 text-right text-gray-500">
-      <% end %>
-        <%= competition_record.squat_third_attempt_result_i18n %>
-      </p>
-    </div>
-  </div>
+  <% end %>
   <!-- BP試技結果 -->
   <div class="border-b-2 border-dashed py-2">
     <div class="flex items-center justify-between mb-3">
@@ -128,61 +130,63 @@
     </div>
   </div>
   <!-- DL試技結果 -->
-  <div class="border-b-2 border-dashed py-2">
-    <div class="flex items-center justify-between mb-3">
-      <h2 class="font-bold mr-2">デッドリフト</h2>
-      <%= link_to edit_competition_deadlift_path(@competition), class: "flex items-center" do %>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="h-5 w-5" fill="#fda4af" > <!-- アイコンの大きさを設定 -->
-          <path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z"/>
-        </svg>
-      <% end %>
+  <% unless @competition.category == "シングルベンチプレス" %>
+    <div class="border-b-2 border-dashed py-2">
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="font-bold mr-2">デッドリフト</h2>
+        <%= link_to edit_competition_deadlift_path(@competition), class: "flex items-center" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="h-5 w-5" fill="#fda4af" > <!-- アイコンの大きさを設定 -->
+            <path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z"/>
+          </svg>
+        <% end %>
+      </div>
+      <!-- DL第１試技 -->
+      <div class="flex flex-row pb-1">
+        <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
+        <p class="text-sm basis-1/3 text-right"> <%= competition_record.deadlift_first_attempt %> kg</p>
+        <!-- 判定結果 -->
+        <% if competition_record.deadlift_first_success? %>
+          <p class="text-sm basis-1/3 text-right text-green-500">
+        <% elsif competition_record.deadlift_first_failure? %>
+          <p class="text-sm basis-1/3 text-right text-red-500">
+        <% elsif competition_record.deadlift_first_not_attempted? %>
+          <p class="text-sm basis-1/3 text-right text-gray-500">
+        <% end %>
+          <%= competition_record.deadlift_first_attempt_result_i18n %>
+        </p>
+      </div>
+      <!-- DL第2試技 -->
+      <div class="flex flex-row pb-1">
+        <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.second_attempt') %> </h3>
+        <p class="text-sm basis-1/3 text-right"> <%= competition_record.deadlift_second_attempt %> kg</p>
+        <!-- 判定結果 -->
+        <% if competition_record.deadlift_second_success? %>
+          <p class="text-sm basis-1/3 text-right text-green-500">
+        <% elsif competition_record.deadlift_second_failure? %>
+          <p class="text-sm basis-1/3 text-right text-red-500">
+        <% elsif competition_record.deadlift_second_not_attempted? %>
+          <p class="text-sm basis-1/3 text-right text-gray-500">
+        <% end %>
+          <%= competition_record.deadlift_second_attempt_result_i18n %>
+        </p>
+      </div>
+      <!-- DLDL第3試技 -->
+      <div class="flex flex-row pb-1">
+        <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.third_attempt') %> </h3>
+        <p class="text-sm basis-1/3 text-right"> <%= competition_record.deadlift_third_attempt %> kg</p>
+        <!-- 判定結果 -->
+        <% if competition_record.deadlift_third_success? %>
+          <p class="text-sm basis-1/3 text-right text-green-500">
+        <% elsif competition_record.deadlift_third_failure? %>
+          <p class="text-sm basis-1/3 text-right text-red-500">
+        <% elsif competition_record.deadlift_third_not_attempted? %>
+          <p class="text-sm basis-1/3 text-right text-gray-500">
+        <% end %>
+          <%= competition_record.deadlift_third_attempt_result_i18n %>
+        </p>
+      </div>
     </div>
-    <!-- DL第１試技 -->
-    <div class="flex flex-row pb-1">
-      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
-      <p class="text-sm basis-1/3 text-right"> <%= competition_record.deadlift_first_attempt %> kg</p>
-      <!-- 判定結果 -->
-      <% if competition_record.deadlift_first_success? %>
-        <p class="text-sm basis-1/3 text-right text-green-500">
-      <% elsif competition_record.deadlift_first_failure? %>
-        <p class="text-sm basis-1/3 text-right text-red-500">
-      <% elsif competition_record.deadlift_first_not_attempted? %>
-        <p class="text-sm basis-1/3 text-right text-gray-500">
-      <% end %>
-        <%= competition_record.deadlift_first_attempt_result_i18n %>
-      </p>
-    </div>
-    <!-- DL第2試技 -->
-    <div class="flex flex-row pb-1">
-      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.second_attempt') %> </h3>
-      <p class="text-sm basis-1/3 text-right"> <%= competition_record.deadlift_second_attempt %> kg</p>
-      <!-- 判定結果 -->
-      <% if competition_record.deadlift_second_success? %>
-        <p class="text-sm basis-1/3 text-right text-green-500">
-      <% elsif competition_record.deadlift_second_failure? %>
-        <p class="text-sm basis-1/3 text-right text-red-500">
-      <% elsif competition_record.deadlift_second_not_attempted? %>
-        <p class="text-sm basis-1/3 text-right text-gray-500">
-      <% end %>
-        <%= competition_record.deadlift_second_attempt_result_i18n %>
-      </p>
-    </div>
-    <!-- DLDL第3試技 -->
-    <div class="flex flex-row pb-1">
-      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.third_attempt') %> </h3>
-      <p class="text-sm basis-1/3 text-right"> <%= competition_record.deadlift_third_attempt %> kg</p>
-      <!-- 判定結果 -->
-      <% if competition_record.deadlift_third_success? %>
-        <p class="text-sm basis-1/3 text-right text-green-500">
-      <% elsif competition_record.deadlift_third_failure? %>
-        <p class="text-sm basis-1/3 text-right text-red-500">
-      <% elsif competition_record.deadlift_third_not_attempted? %>
-        <p class="text-sm basis-1/3 text-right text-gray-500">
-      <% end %>
-        <%= competition_record.deadlift_third_attempt_result_i18n %>
-      </p>
-    </div>
-  </div>
+  <% end %>
   <!-- コメント -->
   <div class="border-b-2 border-dashed py-2">
     <div class="flex items-center justify-between mb-3">

--- a/app/views/record/bench_presses/new.html.erb
+++ b/app/views/record/bench_presses/new.html.erb
@@ -1,12 +1,16 @@
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
-      <div class="mb-5">
+      <div class="mb-5 flex justify-center">
 				<ul class="steps">
 					<li class="step step-primary text-[10px]">検量体重</li>
-					<li class="step step-primary text-[10px]">スクワット</li>
+					<% unless @competition.category == "シングルベンチプレス" %>
+						<li class="step step-primary text-[10px]">スクワット</li>
+					<% end %>
 					<li class="step step-primary text-[10px] text-orange-600 font-bold">ベンチプレス</li>
-					<li class="step text-[10px]">デッドリフト</li>
+					<% unless @competition.category == "シングルベンチプレス" %>
+						<li class="step text-[10px]">デッドリフト</li>
+					<% end %>
 					<li class="step text-[10px]">振り返り<br>コメント</li>
 				</ul>
 			</div>

--- a/app/views/record/comments/new.html.erb
+++ b/app/views/record/comments/new.html.erb
@@ -1,12 +1,16 @@
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
-      <div class="mb-5">
+      <div class="mb-5 flex justify-center">
 				<ul class="steps">
 					<li class="step step-primary text-[10px]">検量体重</li>
-					<li class="step step-primary text-[10px]">スクワット</li>
+          <% unless @competition.category == "シングルベンチプレス" %>
+					  <li class="step step-primary text-[10px]">スクワット</li>
+          <% end %>
 					<li class="step step-primary text-[10px]">ベンチプレス</li>
-					<li class="step step-primary text-[10px]">デッドリフト</li>
+          <% unless @competition.category == "シングルベンチプレス" %>
+					  <li class="step step-primary text-[10px]">デッドリフト</li>
+          <% end %>
 					<li class="step step-primary text-[10px] text-orange-600 font-bold">振り返り<br>コメント</li>
 				</ul>
 			</div>

--- a/app/views/record/weigh_ins/new.html.erb
+++ b/app/views/record/weigh_ins/new.html.erb
@@ -1,12 +1,16 @@
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
-      <div class="mb-5">
+      <div class="mb-5 flex justify-center">
 				<ul class="steps">
 					<li class="step step-primary text-[10px] text-orange-600 font-bold">検量体重</li>
-					<li class="step text-[10px]">スクワット</li>
+					<% unless @competition.category == "シングルベンチプレス" %>
+						<li class="step text-[10px]">スクワット</li>
+					<% end %>
 					<li class="step text-[10px]">ベンチプレス</li>
-					<li class="step text-[10px]">デッドリフト</li>
+					<% unless @competition.category == "シングルベンチプレス" %>
+						<li class="step text-[10px]">デッドリフト</li>
+					<% end %>
 					<li class="step text-[10px]">振り返り<br>コメント</li>
 				</ul>
 			</div>


### PR DESCRIPTION
## 変更の概要

* 変更の概要
  大会情報の、大会カテゴリーがベンチプレスのとき

  - 試技結果ステップ入力時は「スクワット」「デッドリフト」の入力ページを表示させない
  - 試技結果詳細ページは、「スクワット」「デッドリフト」を表示しない

* close #150

## なぜこの変更をするのか

ベンチプレスを選択したのにも関わらず、
ステップ入力時に「スクワット」「デッドリフト」の
入力フォームが出現するのは、無駄であるため。
試技結果詳細ページでも、それらの情報は不要である。

不要なものは表示させないため
