### PR TITLE
fix テキストフィールドのフォントサイズを16pxに指定

### DIFF
--- a/app/views/competitions/_form.html.erb
+++ b/app/views/competitions/_form.html.erb
@@ -4,7 +4,7 @@
       <%= f.label :name, class: 'mr-2' %>
       <p class="text-red-500">(必須)</p>
     </div>
-      <%= f.text_field :name, class: 'input input-bordered input-sm rounded w-full max-w-xs', placeholder:"大会名"%>
+      <%= f.text_field :name, class: 'input input-bordered input-sm rounded w-full max-w-xs text-base', placeholder:"大会名"%>
       <%= render 'shared/error_messages', object: f.object, attribute: :name %>
   </label>
   <label class="form-control w-full max-w-xs mb-6">
@@ -12,14 +12,14 @@
       <%= f.label :venue, class: 'mr-2' %>
       <p class="text-slate-500">(任意)</p>
     </div>
-      <%= f.text_field :venue, class: 'input input-bordered input-sm rounded w-full max-w-xs', placeholder:"会場名" %>
+      <%= f.text_field :venue, class: 'input input-bordered input-sm rounded w-full max-w-xs text-base', placeholder:"会場名" %>
   </label>
   <label class="form-control w-full max-w-xs mb-6">
     <div class="label p-0 flex justify-start items-center">
       <%= f.label :date, class: 'mr-2' %>
       <p class="text-red-500">(必須)</p>
     </div>
-      <%= f.date_field :date, class: 'input input-bordered input-sm rounded w-full max-w-xs', placeholder:"開催日" %>
+      <%= f.date_field :date, class: 'input input-bordered input-sm rounded w-full max-w-xs text-base', placeholder:"開催日" %>
       <%= render 'shared/error_messages', object: f.object, attribute: :date %>
   </label>
   <!-- ここからセレクトボックス -->

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -9,7 +9,7 @@
             <%= f.label :name, class: 'mr-2' %>
             <p class="text-red-500">(必須)</p>
           </div>
-          <%= f.text_field :name, class: 'input input-bordered', placeholder:"name"%>
+          <%= f.text_field :name, class: 'input input-bordered text-base', placeholder:"name"%>
           <%= render 'shared/error_messages', object: f.object, attribute: :name %>
         </div>
         <!-- Profileの性別と生年月日入力フォームここから -->

--- a/app/views/record/bench_presses/edit.html.erb
+++ b/app/views/record/bench_presses/edit.html.erb
@@ -11,7 +11,7 @@
 						<div class="flex justify-between">
 							<%= f.label :benchpress_first_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -45,7 +45,7 @@
 						<div class="flex justify-between">
 							<%= f.label :benchpress_second_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -79,7 +79,7 @@
 						<div class="flex justify-between">
 							<%= f.label :benchpress_third_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>

--- a/app/views/record/bench_presses/new.html.erb
+++ b/app/views/record/bench_presses/new.html.erb
@@ -24,7 +24,7 @@
 						<div class="flex justify-between">
 							<%= f.label :benchpress_first_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -58,7 +58,7 @@
 						<div class="flex justify-between">
 							<%= f.label :benchpress_second_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -92,7 +92,7 @@
 						<div class="flex justify-between">
 							<%= f.label :benchpress_third_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>

--- a/app/views/record/comments/edit.html.erb
+++ b/app/views/record/comments/edit.html.erb
@@ -8,7 +8,7 @@
             <div class="label p-0 flex justify-start items-center">
               <p class="text-slate-500">(任意)</p>
             </div>
-              <%= f.text_area :comment, class:"textarea textarea-bordered h-80" %>
+              <%= f.text_area :comment, class:"textarea textarea-bordered h-80 text-base" %>
           </label>
           <!-- ボタン -->
           <div class="form-control mt-6 flex flex-row justify-center">

--- a/app/views/record/comments/new.html.erb
+++ b/app/views/record/comments/new.html.erb
@@ -21,7 +21,7 @@
             <div class="label p-0 flex justify-start items-center">
               <p class="text-slate-500">(任意)</p>
             </div>
-              <%= f.text_area :comment, class:"textarea textarea-bordered h-80" %>
+              <%= f.text_area :comment, class:"textarea textarea-bordered h-80 text-base" %>
           </label>
           <!-- ボタン -->
           <div class="form-control mt-6 flex flex-row justify-center">

--- a/app/views/record/deadlifts/edit.html.erb
+++ b/app/views/record/deadlifts/edit.html.erb
@@ -11,7 +11,7 @@
 						<div class="flex justify-between">
 							<%= f.label :deadlift_first_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -45,7 +45,7 @@
 						<div class="flex justify-between">
 							<%= f.label :deadlift_second_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -79,7 +79,7 @@
 						<div class="flex justify-between">
 							<%= f.label :deadlift_third_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>

--- a/app/views/record/deadlifts/new.html.erb
+++ b/app/views/record/deadlifts/new.html.erb
@@ -20,7 +20,7 @@
 						<div class="flex justify-between">
 							<%= f.label :deadlift_first_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -54,7 +54,7 @@
 						<div class="flex justify-between">
 							<%= f.label :deadlift_second_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -88,7 +88,7 @@
 						<div class="flex justify-between">
 							<%= f.label :deadlift_third_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>

--- a/app/views/record/squats/edit.html.erb
+++ b/app/views/record/squats/edit.html.erb
@@ -11,7 +11,7 @@
 						<div class="flex justify-between">
 							<%= f.label :squat_first_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -45,7 +45,7 @@
 						<div class="flex justify-between">
 							<%= f.label :squat_second_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -79,7 +79,7 @@
 						<div class="flex justify-between">
 							<%= f.label :squat_third_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>

--- a/app/views/record/squats/new.html.erb
+++ b/app/views/record/squats/new.html.erb
@@ -20,7 +20,7 @@
 						<div class="flex justify-between">
 							<%= f.label :squat_first_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -54,7 +54,7 @@
 						<div class="flex justify-between">
 							<%= f.label :squat_second_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -88,7 +88,7 @@
 						<div class="flex justify-between">
 							<%= f.label :squat_third_attempt, class: 'text-xl' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder: "重量" %>
+								<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
 							</label>
 						</div>

--- a/app/views/record/weigh_ins/edit.html.erb
+++ b/app/views/record/weigh_ins/edit.html.erb
@@ -10,7 +10,7 @@
 							<p class="text-red-500">(必須)</p>
 						</div>
 						<label class="form-control flex flex-row">
-							<%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder:"検量体重"%>
+							<%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder:"検量体重"%>
 							<span>kg</span>
 						</label>
 					</div>

--- a/app/views/record/weigh_ins/new.html.erb
+++ b/app/views/record/weigh_ins/new.html.erb
@@ -23,7 +23,7 @@
 							<p class="text-red-500">(必須)</p>
 						</div>
 						<label class="form-control flex flex-row">
-							<%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-32 mr-2', placeholder:"検量体重"%>
+							<%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder:"検量体重"%>
 							<span>kg</span>
 						</label>
 					</div>


### PR DESCRIPTION

## 変更の概要

 スマホの入力フォームが勝手にズームされてしまう問題を解決

* close #159

## なぜこの変更をするのか
スマホの入力フォームが勝手にズームされてしまう問題
なぜ起きているか
iosの仕様により16px以下のfont-sizeだと、入力フォームにズームしてしまう
font-sizeが14pxだったため、16pxにする必要があった