### PR TITLE
fix: 大会情報記録・編集ページのレイアウト修正

### DIFF
--- a/app/helpers/competitions_helper.rb
+++ b/app/helpers/competitions_helper.rb
@@ -1,2 +1,5 @@
 module CompetitionsHelper
+  def weight_classes_for(user)
+    user.profile.gender == 'man' ? Competition::WEIGHT_CLASSES['男子'] : Competition::WEIGHT_CLASSES['女子']
+  end
 end

--- a/app/views/competitions/_form.html.erb
+++ b/app/views/competitions/_form.html.erb
@@ -1,68 +1,95 @@
 <%= form_with model: competition do |f| %>
+  <!-- 大会名 -->
   <label class="form-control w-full max-w-xs mb-6">
     <div class="label p-0 flex justify-start items-center">
-      <%= f.label :name, class: 'mr-2' %>
+      <%= f.label :name, class: 'mr-2 font-semibold' %>
       <p class="text-red-500">(必須)</p>
     </div>
       <%= f.text_field :name, class: 'input input-bordered input-sm rounded w-full max-w-xs text-base', placeholder:"大会名"%>
       <%= render 'shared/error_messages', object: f.object, attribute: :name %>
   </label>
+  <!-- 会場名 -->
   <label class="form-control w-full max-w-xs mb-6">
     <div class="label p-0 flex justify-start items-center">
-      <%= f.label :venue, class: 'mr-2' %>
+      <%= f.label :venue, class: 'mr-2 font-semibold' %>
       <p class="text-slate-500">(任意)</p>
     </div>
       <%= f.text_field :venue, class: 'input input-bordered input-sm rounded w-full max-w-xs text-base', placeholder:"会場名" %>
   </label>
+  <!-- 開催日 -->
   <label class="form-control w-full max-w-xs mb-6">
     <div class="label p-0 flex justify-start items-center">
-      <%= f.label :date, class: 'mr-2' %>
+      <%= f.label :date, class: 'mr-2 font-semibold' %>
       <p class="text-red-500">(必須)</p>
     </div>
       <%= f.date_field :date, class: 'input input-bordered input-sm rounded w-full max-w-xs text-base', placeholder:"開催日" %>
       <%= render 'shared/error_messages', object: f.object, attribute: :date %>
   </label>
-  <!-- ここからセレクトボックス -->
+  <!-- ここから選択制 -->
   <!-- 大会種別 -->
   <label class="form-control w-full max-w-xs mb-6">
     <div class="label p-0 flex justify-start items-center">
-      <%= f.label :competition_type, class: 'mr-2' %>
+      <%= f.label :competition_type, class: 'mr-2 font-semibold' %>
       <p class="text-red-500">(必須)</p>
     </div>
-      <%= f.select :competition_type,
-      Competition.competition_types_i18n.invert.map { |key, value| [key, value] },
-      {include_blank: '選択してください'},
-      { class: 'select select-bordered select-sm w-full max-w-xs' } %>
+    <div class="form-control mb-3">
+      <div class="flex flex-col mt-2">
+        <label class="flex items-center mb-3">
+          <%= f.radio_button :competition_type, 'official', class: 'radio radio-primary' %>
+          <span class="ml-2"><%= f.label :competition_type, Competition.competition_types_i18n["official"] %></span>
+        </label>
+        <label class="flex items-center">
+          <%= f.radio_button :competition_type, 'official', class: 'radio radio-primary' %>
+          <span class="ml-2"><%= f.label :competition_type, Competition.competition_types_i18n["unofficial"] %></span>
+        </label>
+      </div>
       <%= render 'shared/error_messages', object: f.object, attribute: :competition_type %>
+    </div>
   </label>
   <!-- ギアカテゴリ -->
   <label class="form-control w-full max-w-xs mb-6">
     <div class="label p-0 flex justify-start items-center">
-      <%= f.label :gearcategory_type, class: 'mr-2' %>
+      <%= f.label :gearcategory_type, class: 'mr-2 font-semibold' %>
       <p class="text-red-500">(必須)</p>
     </div>
-      <%= f.select :gearcategory_type,
-      Competition.gearcategory_types_i18n.invert.map { |key, value| [key, value] },
-      {include_blank: '選択してください'},
-      { class: 'select select-bordered select-sm w-full max-w-xs'} %>
+    <div class="form-control mb-3">
+      <div class="flex flex-col mt-2">
+        <label class="flex items-center mb-3">
+          <%= f.radio_button :gearcategory_type, 'raw', class: 'radio radio-primary' %>
+          <span class="ml-2"><%= f.label :gearcategory_type, Competition.gearcategory_types_i18n["raw"] %></span>
+        </label>
+        <label class="flex items-center">
+          <%= f.radio_button :gearcategory_type, 'equipped', class: 'radio radio-primary' %>
+          <span class="ml-2"><%= f.label :gearcategory_type, Competition.gearcategory_types_i18n["equipped"] %></span>
+        </label>
+      </div>
       <%= render 'shared/error_messages', object: f.object, attribute: :gearcategory_type %>
+    </div>
   </label>
   <!-- 競技種別 -->
   <label class="form-control w-full max-w-xs mb-6">
     <div class="label p-0 flex justify-start items-center">
-      <%= f.label :category, class: 'mr-2' %>
+      <%= f.label :category, class: 'mr-2 font-semibold' %>
       <p class="text-red-500">(必須)</p>
     </div>
-      <%= f.select :category,
-      options_for_select(Competition::CATEGORIES, f.object.category),
-      {include_blank: '選択してください'},
-      { class: 'select select-bordered select-sm w-full max-w-xs'} %>
+    <div class="form-control mb-3">
+      <div class="flex flex-col mt-2">
+        <label class="flex items-center mb-3">
+          <%= f.radio_button :category, "パワーリフティング", class: 'radio radio-primary' %>
+          <span class="ml-2"><%= f.label :category, "パワーリフティング" %></span>
+        </label>
+        <label class="flex items-center">
+          <%= f.radio_button :category, "シングルベンチプレス", class: 'radio radio-primary' %>
+          <span class="ml-2"><%= f.label :category, "シングルベンチプレス" %></span>
+        </label>
+      </div>
       <%= render 'shared/error_messages', object: f.object, attribute: :category %>
+    </div>
   </label>
   <!-- 年齢別区分 -->
   <label class="form-control w-full max-w-xs mb-6">
     <div class="label p-0 flex justify-start items-center">
-      <%= f.label :age_group, class: 'mr-2' %>
+      <%= f.label :age_group, class: 'mr-2 font-semibold' %>
       <p class="text-red-500">(必須)</p>
     </div>
       <%= f.select :age_group,
@@ -74,7 +101,7 @@
   <!-- 体重区分 -->
   <label class="form-control w-full max-w-xs mb-6">
     <div class="label p-0 flex justify-start items-center">
-      <%= f.label :weight_class, class: 'mr-2' %>
+      <%= f.label :weight_class, class: 'mr-2 font-semibold' %>
       <p class="text-red-500">(必須)</p>
     </div>
       <%= f.select :weight_class,
@@ -84,7 +111,7 @@
       <%= render 'shared/error_messages', object: f.object, attribute: :weight_class %>
   </label>
   <!-- ここまでセレクトボックス -->
-  <div class="form-control mt-6">
-      <%= f.submit class: 'btn btn-primary' %>
+  <div class="form-control mt-6 flex flex-row justify-center">
+      <%= f.submit class: 'btn btn-secondary btn-sm w-24' %>
   </div>
 <% end %>

--- a/app/views/competitions/_form.html.erb
+++ b/app/views/competitions/_form.html.erb
@@ -78,7 +78,7 @@
       <p class="text-red-500">(必須)</p>
     </div>
       <%= f.select :weight_class,
-      grouped_options_for_select(Competition::WEIGHT_CLASSES, f.object.weight_class),
+      options_for_select(weight_classes_for(current_user), f.object.weight_class),
       {include_blank: '選択してください'},
       { class: 'select select-bordered select-sm w-full max-w-xs'} %>
       <%= render 'shared/error_messages', object: f.object, attribute: :weight_class %>

--- a/app/views/competitions/edit.html.erb
+++ b/app/views/competitions/edit.html.erb
@@ -1,7 +1,7 @@
-<div class="hero min-h-screen bg-base-200">
+<div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
       <!-- ここからform_withを使う形に修正 -->
-    <h1 class="text-2xl">大会情報の編集</h1>
+    <h1 class="text-2xl font-bold">大会情報の編集</h1>
     <%= render 'form', competition: @competition %>
       <!-- ここまでform_withを使う形に修正 -->
   </div>

--- a/app/views/competitions/new.html.erb
+++ b/app/views/competitions/new.html.erb
@@ -1,7 +1,7 @@
-<div class="hero min-h-screen bg-base-200">
+<div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
       <!-- ここからform_withを使う形に修正 -->
-    <h1 class="text-2xl">大会情報の登録</h1>
+    <h1 class="text-2xl font-bold">大会情報の登録</h1>
     <%= render 'form', competition: @competition %>
       <!-- ここまでform_withを使う形に修正 -->
   </div>

--- a/app/views/record/bench_presses/edit.html.erb
+++ b/app/views/record/bench_presses/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
-      <h1 class="text-2xl text-center mb-5">ベンチプレス結果 編集</h1>
+      <h1 class="text-2xl text-center mb-5 font-bold">ベンチプレス結果 編集</h1>
 			<%= form_with model: @bench_press, url: competition_bench_presse_path(@competition), method: "patch" do |f| %>
 				<!-- ベンチプレス試技結果 -->
 				<!-- ベンチプレス第１試技 -->
@@ -9,7 +9,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :benchpress_first_attempt, class: 'text-xl' %>
+							<%= f.label :benchpress_first_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
@@ -43,7 +43,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :benchpress_second_attempt, class: 'text-xl' %>
+							<%= f.label :benchpress_second_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
@@ -77,7 +77,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :benchpress_third_attempt, class: 'text-xl' %>
+							<%= f.label :benchpress_third_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>

--- a/app/views/record/bench_presses/new.html.erb
+++ b/app/views/record/bench_presses/new.html.erb
@@ -14,7 +14,7 @@
 					<li class="step text-[10px]">振り返り<br>コメント</li>
 				</ul>
 			</div>
-      <h1 class="text-2xl text-center mb-5">ベンチプレス結果登録</h1>
+      <h1 class="text-2xl text-center mb-5 font-bold">ベンチプレス結果 登録</h1>
 			<%= form_with model: @bench_press, url: competition_bench_presse_path(@competition)  do |f| %>
 				<!-- ベンチプレス試技結果 -->
 				<!-- ベンチプレス第１試技 -->
@@ -22,7 +22,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :benchpress_first_attempt, class: 'text-xl' %>
+							<%= f.label :benchpress_first_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
@@ -56,7 +56,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :benchpress_second_attempt, class: 'text-xl' %>
+							<%= f.label :benchpress_second_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
@@ -90,7 +90,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :benchpress_third_attempt, class: 'text-xl' %>
+							<%= f.label :benchpress_third_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>

--- a/app/views/record/comments/edit.html.erb
+++ b/app/views/record/comments/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
-      <h1 class="text-2xl text-center mb-5">振り返りコメント 編集</h1>
+      <h1 class="text-2xl text-center mb-5 font-bold">振り返りコメント 編集</h1>
 			  <%= form_with model: @comment, url: competition_comment_path(@competition), method: "patch" do |f| %>
           <!-- 振り返りコメント -->
           <label class="form-control mb-6">

--- a/app/views/record/comments/new.html.erb
+++ b/app/views/record/comments/new.html.erb
@@ -14,7 +14,7 @@
 					<li class="step step-primary text-[10px] text-orange-600 font-bold">振り返り<br>コメント</li>
 				</ul>
 			</div>
-      <h1 class="text-2xl text-center mb-5">振り返りコメント</h1>
+      <h1 class="text-2xl text-center mb-5 font-bold">振り返りコメント</h1>
 			  <%= form_with model: @comment, url: competition_comment_path(@competition)  do |f| %>
           <!-- 振り返りコメント -->
           <label class="form-control mb-6">

--- a/app/views/record/deadlifts/edit.html.erb
+++ b/app/views/record/deadlifts/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
-      <h1 class="text-2xl text-center mb-5">デッドリフト結果 編集</h1>
+      <h1 class="text-2xl text-center mb-5 font-bold">デッドリフト結果 編集</h1>
 			<%= form_with model: @deadlift, url: competition_deadlift_path(@competition), method: "patch" do |f| %>
 				<!-- デッドリフト試技結果 -->
 				<!-- デッドリフト第１試技 -->
@@ -9,7 +9,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :deadlift_first_attempt, class: 'text-xl' %>
+							<%= f.label :deadlift_first_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
@@ -43,7 +43,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :deadlift_second_attempt, class: 'text-xl' %>
+							<%= f.label :deadlift_second_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
@@ -77,7 +77,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :deadlift_third_attempt, class: 'text-xl' %>
+							<%= f.label :deadlift_third_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>

--- a/app/views/record/deadlifts/new.html.erb
+++ b/app/views/record/deadlifts/new.html.erb
@@ -10,7 +10,7 @@
 					<li class="step text-[10px]">振り返り<br>コメント</li>
 				</ul>
 			</div>
-      <h1 class="text-2xl text-center mb-5">デッドリフト結果登録</h1>
+      <h1 class="text-2xl text-center mb-5 font-bold">デッドリフト結果 登録</h1>
 			<%= form_with model: @deadlift, url: competition_deadlift_path(@competition)  do |f| %>
 				<!-- デッドリフト試技結果 -->
 				<!-- デッドリフト第１試技 -->
@@ -18,7 +18,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :deadlift_first_attempt, class: 'text-xl' %>
+							<%= f.label :deadlift_first_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
@@ -52,7 +52,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :deadlift_second_attempt, class: 'text-xl' %>
+							<%= f.label :deadlift_second_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
@@ -86,7 +86,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :deadlift_third_attempt, class: 'text-xl' %>
+							<%= f.label :deadlift_third_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>

--- a/app/views/record/squats/edit.html.erb
+++ b/app/views/record/squats/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
-      <h1 class="text-2xl text-center mb-5">スクワット結果登録</h1>
+      <h1 class="text-2xl text-center mb-5 font-bold">スクワット結果 登録</h1>
 			<%= form_with model: @squat, url: competition_squat_path(@competition), method: "patch" do |f| %>
 				<!-- スクワット試技結果 -->
 				<!-- スクワット第１試技 -->
@@ -9,7 +9,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :squat_first_attempt, class: 'text-xl' %>
+							<%= f.label :squat_first_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
@@ -43,7 +43,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :squat_second_attempt, class: 'text-xl' %>
+							<%= f.label :squat_second_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
@@ -77,7 +77,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :squat_third_attempt, class: 'text-xl' %>
+							<%= f.label :squat_third_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>

--- a/app/views/record/squats/new.html.erb
+++ b/app/views/record/squats/new.html.erb
@@ -10,7 +10,7 @@
 					<li class="step text-[10px]">振り返り<br>コメント</li>
 				</ul>
 			</div>
-      <h1 class="text-2xl text-center mb-5">スクワット結果登録</h1>
+      <h1 class="text-2xl text-center mb-5 font-bold">スクワット結果登録</h1>
 			<%= form_with model: @squat, url: competition_squat_path(@competition)  do |f| %>
 				<!-- スクワット試技結果 -->
 				<!-- スクワット第１試技 -->
@@ -18,7 +18,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :squat_first_attempt, class: 'text-xl' %>
+							<%= f.label :squat_first_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
@@ -52,7 +52,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :squat_second_attempt, class: 'text-xl' %>
+							<%= f.label :squat_second_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>
@@ -86,7 +86,7 @@
 					<!-- 重量-->
 					<div class="flex flex-col mb-3">
 						<div class="flex justify-between">
-							<%= f.label :squat_third_attempt, class: 'text-xl' %>
+							<%= f.label :squat_third_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
 								<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
 								<span>kg</span>

--- a/app/views/record/weigh_ins/edit.html.erb
+++ b/app/views/record/weigh_ins/edit.html.erb
@@ -1,12 +1,12 @@
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
-      <h1 class="text-2xl text-center mb-5">検量体重　編集</h1>
+      <h1 class="text-2xl text-center mb-5 font-bold">検量体重 編集</h1>
 			<%= form_with model: @weigh_in, url: competition_weigh_in_path(@competition), method: "patch" do |f| %>
 				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
 					<div class="flex justify-between">
 						<div class="label p-0 flex justify-start items-center">
-							<%= f.label :weight, class: 'mr-2'%>
+							<%= f.label :weight, class: 'mr-2 font-semibold'%>
 							<p class="text-red-500">(必須)</p>
 						</div>
 						<label class="form-control flex flex-row">

--- a/app/views/record/weigh_ins/new.html.erb
+++ b/app/views/record/weigh_ins/new.html.erb
@@ -14,12 +14,12 @@
 					<li class="step text-[10px]">振り返り<br>コメント</li>
 				</ul>
 			</div>
-      <h1 class="text-2xl text-center mb-5">検量体重登録</h1>
+      <h1 class="text-2xl text-center mb-5 font-bold">検量体重登録</h1>
 			<%= form_with model: @weigh_in, url: competition_weigh_in_path(@competition)  do |f| %>
 				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
 					<div class="flex justify-between">
 						<div class="label p-0 flex justify-start items-center">
-							<%= f.label :weight, class: 'mr-2'%>
+							<%= f.label :weight, class: 'mr-2 font-semibold'%>
 							<p class="text-red-500">(必須)</p>
 						</div>
 						<label class="form-control flex flex-row">


### PR DESCRIPTION
## 変更の概要

* 階級区分のセレクトボックスの選択肢をユーザーのプロフィールによって変える
男性だったら、男子の階級のみ表示
女性だったら、女子の階級のみ表示

- 選択肢が二つしかないセレクトボックスは、ラジオボタンに変更した
大会種別(公式大会か、非公式か)
競技種別(パワーリフティングかベンチプレスか)
ギアの種別(ノーギアかフルギアか)

- 試技結果のタイトルと入力項目のラベルを太字にした
大会情報フォームと同じレイアウトにしたため

* 関連するIssueやプルリクエスト
close #140 

## なぜこの変更をするのか

> * 階級区分のセレクトボックスの選択肢をユーザーのプロフィールによって変える

女性のユーザーなのに、男性の階級が選択肢で出ても邪魔だから。
選択しやすいように、異性の階級は選択肢から排除した。

> - 選択肢が二つしかないセレクトボックスは、ラジオボタンに変更した

二つだけであれば、選択肢が何があるか一目でわかるラジオボタンのほうが良い。


## 備考

* 年齢区分をユーザーのプロフによって選択肢を変更する機能は別issueでたてた
feature #168 