### PR TITLE
add: db:migrateをコメントアウトして、db:resetコマンドの追加

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,8 @@ rm -f /app/tmp/pids/server.pid
 
 RAILS_ENV=production bundle exec rails assets:precompile
 RAILS_ENV=production bundle exec rails assets:clean
-RAILS_ENV=production bundle exec rails db:migrate
+# RAILS_ENV=production bundle exec rails db:migrate
+RAILS_ENV=production DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:reset
 
 # コンテナーのプロセスを実行する。（Dockerfile 内の CMD に設定されているもの。）
 exec "$@"


### PR DESCRIPTION
## なぜ必要か

- 現状のアプリ進捗
  - ユーザーのプロフィール、出場した大会情報とその試技結果をもとに試技成績を計算できる
 

- 発生した問題点
  -  プロフ機能をつくる前に作成したアカウントがいるので、
      そのアカウントだと試技成績計算できなくて例外出てしまう。
  - resetしてもう1回作り直す
  - 現状、自分と触ってくださった人など、テストユーザーのみなので消しても問題ないとする

## 順番

- 使用するコマンド
`rails db:reset`
使う理由: schema.rb が最新のマイグレーションファイルを全て反映している状態なので
動作: データベースをドロップし、再作成して、schema.rb を基にデータベースを作成する。
   

- [ ] 開発環境で動作試験済。問題なくresetできた
- [ ] entrypoint.shこうする
```
#!/bin/bash
set -e

# Rails に対応したファイル server.pid が存在しているかもしれないので削除する。
rm -f /app/tmp/pids/server.pid

RAILS_ENV=production bundle exec rails assets:precompile
RAILS_ENV=production bundle exec rails assets:clean
# RAILS_ENV=production bundle exec rails db:migrate
RAILS_ENV=production DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:reset

# コンテナーのプロセスを実行する。（Dockerfile 内の CMD に設定されているもの。）
exec "$@"
```
