### PR TITLE
add: 試技結果計算の、既存レコードの更新機能

### DIFF
--- a/app/controllers/record/bench_presses_controller.rb
+++ b/app/controllers/record/bench_presses_controller.rb
@@ -1,6 +1,7 @@
 class Record::BenchPressesController < ApplicationController
   before_action :set_competition
   before_action :set_competition_record, only: %i[ edit update ]
+  before_action :set_competition_result, only: %i[ update ]
   skip_before_action :set_bottom_navi, only: %i[ new edit ]
 
   def new
@@ -51,8 +52,13 @@ class Record::BenchPressesController < ApplicationController
       benchpress_second_attempt_result: @bench_press.benchpress_second_attempt_result,
       benchpress_third_attempt_result: @bench_press.benchpress_third_attempt_result
     }
-    # 取得したレコードの値を、ユーザーが入力してきた値に上書きしてupdateする
-    if @competition_record.update(bench_press_update_params)
+    # 取得したレコードの属性の値を入力フォームから受け取った値に変更する
+    @competition_record.assign_attributes(bench_press_update_params)
+    # バリデーション実行
+    if @competition_record.valid?
+      gender = current_user.profile.gender
+      # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
+      @competition_record.result_save(@competition_record, @competition, gender)
       redirect_to competition_path(@competition) # 成功したら詳細ページへ遷移する
     else
       render :edit, status: :unprocessable_entity
@@ -74,5 +80,9 @@ class Record::BenchPressesController < ApplicationController
 
   def set_competition_record
     @competition_record = @competition.competition_record
+  end
+
+  def set_competition_result
+    @competition_result = @competition_record.competition_result
   end
 end

--- a/app/controllers/record/comments_controller.rb
+++ b/app/controllers/record/comments_controller.rb
@@ -20,7 +20,7 @@ class Record::CommentsController < ApplicationController
       @competition_record = CompetitionRecord.new(@competition_record_params)
       # transaction開始
       gender = current_user.profile.gender
-      @competition_record.result_create(@competition_record, @competition, gender)
+      @competition_record.result_save(@competition_record, @competition, gender)
       # セッションをクリアにする
       session.delete(:record)
       # 大会結果詳細ページへ遷移

--- a/app/controllers/record/deadlifts_controller.rb
+++ b/app/controllers/record/deadlifts_controller.rb
@@ -1,6 +1,7 @@
 class Record::DeadliftsController < ApplicationController
   before_action :set_competition
   before_action :set_competition_record, only: %i[ edit update ]
+  before_action :set_competition_result, only: %i[ update ]
   skip_before_action :set_bottom_navi, only: %i[ new edit ]
 
   def new
@@ -46,8 +47,13 @@ class Record::DeadliftsController < ApplicationController
       deadlift_second_attempt_result: @deadlift.deadlift_second_attempt_result,
       deadlift_third_attempt_result: @deadlift.deadlift_third_attempt_result
     }
-    # 取得したレコードの値を、ユーザーが入力してきた値に上書きしてupdateする
-    if @competition_record.update(deadlift_update_params)
+    # 取得したレコードの属性の値を入力フォームから受け取った値に変更する
+    @competition_record.assign_attributes(deadlift_update_params)
+    # バリデーション実行
+    if @competition_record.valid?
+      gender = current_user.profile.gender
+      # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
+      @competition_record.result_save(@competition_record, @competition, gender)
       redirect_to competition_path(@competition) # 成功したら詳細ページへ遷移する
     else
       render :edit, status: :unprocessable_entity
@@ -69,5 +75,9 @@ class Record::DeadliftsController < ApplicationController
 
   def set_competition_record
     @competition_record = @competition.competition_record
+  end
+
+  def set_competition_result
+    @competition_result = @competition_record.competition_result
   end
 end

--- a/app/models/competition_record.rb
+++ b/app/models/competition_record.rb
@@ -207,4 +207,19 @@ class CompetitionRecord < ApplicationRecord
       @competition_result.save!
     end
   end
+
+  def ipf_points_update(competition_record, competition, gender)
+    # IPFポイントの計算をする
+    # 係数a,b,cの決定
+    coefficients = CompetitionResult::COEFFICIENTS[gender][competition.gearcategory_type][competition.category]
+    a = coefficients[:a]
+    b = coefficients[:b]
+    c = coefficients[:c]
+    # 検量体重
+    body_weight = competition_record.weight
+    total_lifted_weight = competition_record.competition_result.total_lifted_weight
+    # IPFポイント計算式
+    ipf_gl_points = total_lifted_weight * 100 / (a - b * Math.exp(-c * body_weight))
+    return ipf_gl_points
+  end
 end

--- a/app/models/competition_record.rb
+++ b/app/models/competition_record.rb
@@ -115,7 +115,7 @@ class CompetitionRecord < ApplicationRecord
     end
   end
 
-  def result_create(competition_record, competition, gender)
+  def result_save(competition_record, competition, gender)
     ActiveRecord::Base.transaction do
       # ステップ1 @competition_recordの内容をテーブルに保存
       competition_record.save!

--- a/app/models/competition_record.rb
+++ b/app/models/competition_record.rb
@@ -117,9 +117,10 @@ class CompetitionRecord < ApplicationRecord
 
   def result_save(competition_record, competition, gender)
     ActiveRecord::Base.transaction do
-      # ステップ1 @competition_recordの内容をテーブルに保存
+      # ステップ1 @competition_recordの内容をテーブルに保存/更新
       competition_record.save!
-      # ステップ2ここからCompetitionResultテーブルのレコード保存のため計算開始
+
+      # ステップ2 ここからCompetitionResultテーブルのレコード保存/更新のため計算開始
       # スクワットの最高重量を算出
       # 試技結果の重量を保存に成功したインスタンスから抽出
       squat_attempt = {
@@ -135,6 +136,7 @@ class CompetitionRecord < ApplicationRecord
       end
       # 成功試技の中で、最高重量を変数に代入
       best_squat_weight = squat_attempts.empty? ? 0 : squat_attempts.max
+
       # ベンチプレスの最高重量を算出
       benchpress_attempt = {
         benchpress_first_attempt: competition_record.benchpress_first_attempt,
@@ -149,6 +151,7 @@ class CompetitionRecord < ApplicationRecord
       end
       # 成功試技の中で、最高重量を変数に代入
       best_benchpress_weight = benchpress_attempts.empty? ? 0 : benchpress_attempts.max
+
       # デッドリフトの最高重量を算出
       deadlift_attempt = {
         deadlift_first_attempt: competition_record.deadlift_first_attempt,
@@ -163,6 +166,7 @@ class CompetitionRecord < ApplicationRecord
       end
       # 成功試技の中で、最高重量を変数に代入
       best_deadlift_weight = deadlift_attempts.empty? ? 0 : deadlift_attempts.max
+
       # トータル重量を出す
       total_lifted_weight =
         case competition.category
@@ -171,6 +175,7 @@ class CompetitionRecord < ApplicationRecord
         when "シングルベンチプレス"
           best_benchpress_weight
         end
+
       # IPFポイントの計算をする
       # 係数a,b,cの決定
       coefficients = CompetitionResult::COEFFICIENTS[gender][competition.gearcategory_type][competition.category]
@@ -190,7 +195,14 @@ class CompetitionRecord < ApplicationRecord
         total_lifted_weight: total_lifted_weight,
         ipf_points: ipf_gl_points,
       }
-      @competition_result = CompetitionResult.new(results_params)
+      if competition_record.competition_result.nil?
+        # 結果がなければ、新しいCompetitionResultインスタンスを作成
+        @competition_result = CompetitionResult.new(results_params)
+      else
+        # 結果登録済ならば、新しいCompetitionResultインスタンスを作成
+        @competition_result = competition_record.competition_result
+        @competition_result.assign_attributes(results_params)
+      end
       # 保存
       @competition_result.save!
     end


### PR DESCRIPTION
## 変更の概要
ユーザーが、
試技結果(competition_records)、大会情報(competitions),関連する試技成績(competition_results)の
計算結果が更新されるようにする

* 関連するIssueやプルリクエスト
close #173 

## なぜこの変更をするのか
試技結果計算に必要なオブジェクトの値が変更になったら、計算結果にも反映させなければならない。

## やったこと

* [x] result_createメソッドをresult_saveメソッドに名前変更
(新規保存・更新も担うため）
* [x] 検量体重、種目の試技結果の重量を変更したら計算結果も更新される
  * competition_resultsレコードの以下のカラムが更新されるか検証済
    - best_種目_weight
    - total_lifted_weight
    - ipf_points
 * [x] 大会情報のギア種別を変更したら計算結果も更新される
   * competition_resultsレコードの以下のカラムが更新されるか検証済
      - ipf_points
  - 検証方法
    - 男性、フルギア、パワーリフティング
    - 男性、フルギア、シングルベンチプレス
    - 男性、ノーギア、パワーリフティング
    - 男性、ノーギア、シングルベンチプレス
    - 女性、フルギア、パワーリフティング
    - 女性、フルギア、シングルベンチプレス
    - 女性、ノーギア、パワーリフティング
    - 女性、ノーギア、シングルベンチプレス
    
  - 確認方法
    
    過去の大会結果をJPFのホームページから参照
    各パターンの条件に一致した大会結果を、実際にアプリに入力・登録
    ブラウザに表示された計算結果と、JPFのホームページの大会結果が一致しているか確認
## やらなかったこと

- [ ] profileの性別が変更されたら、 `ipf_points `も変わる
  - 性別変更ってほぼないし、間違いもしないだろう。優先度低とする。
  - issue作成 #186
