### PR TITLE
fix: 大会情報の編集ページで大会種別が勝手に非公式大会に選択されてしまう件

### DIFF
--- a/app/views/competitions/_form.html.erb
+++ b/app/views/competitions/_form.html.erb
@@ -39,7 +39,7 @@
           <span class="ml-2"><%= f.label :competition_type, Competition.competition_types_i18n["official"] %></span>
         </label>
         <label class="flex items-center">
-          <%= f.radio_button :competition_type, 'official', class: 'radio radio-primary' %>
+          <%= f.radio_button :competition_type, 'unofficial', class: 'radio radio-primary' %>
           <span class="ml-2"><%= f.label :competition_type, Competition.competition_types_i18n["unofficial"] %></span>
         </label>
       </div>


### PR DESCRIPTION
## 変更の概要

ラジオボタンでvalue値が間違っていた
`unoficial` (非公式)が入るべきところ、 `official`(公式)になっていた
修正前
```
<%= f.radio_button :competition_type, 'official'~
```
修正後
```
<%= f.radio_button :competition_type, 'unofficial'~
```

* 関連するIssueやプルリクエスト
close  #184

## なぜこの変更をするのか

大会情報の編集ページにいくと、
大会種別が「公式大会」なのに、
「非公式大会」に勝手にラジオボタンのチェックが入ってしまう問題があったため

viewファイルを調査

「非公式大会」用のラジオボタンのvalue値が間違えていたことが判明
無事に期待される動作をした

期待される動作: 大会情報のレコードがもつ、大会種別が選択されていること

