### PR TITLE
fix: 大会情報編集にて、試技結果の登録状況で競技種別が編集可能か切り替える

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -1,6 +1,6 @@
 class CompetitionsController < ApplicationController
   before_action :set_competition, only: %i[ show edit update destroy ]
-  before_action :set_competition_record, only: %i[ show update ]
+  before_action :set_competition_record, only: %i[ show edit update ]
   before_action :set_competition_result, only: %i[ show update ]
   skip_before_action :set_bottom_navi, only: %i[ new edit ]
 

--- a/app/views/competitions/_form.html.erb
+++ b/app/views/competitions/_form.html.erb
@@ -75,11 +75,11 @@
     <div class="form-control mb-3">
       <div class="flex flex-col mt-2">
         <label class="flex items-center mb-3">
-          <%= f.radio_button :category, "パワーリフティング", class: 'radio radio-primary' %>
+          <%= f.radio_button :category, "パワーリフティング", class: 'radio radio-primary', disabled: @competition_record.present? %>
           <span class="ml-2"><%= f.label :category, "パワーリフティング" %></span>
         </label>
         <label class="flex items-center">
-          <%= f.radio_button :category, "シングルベンチプレス", class: 'radio radio-primary' %>
+          <%= f.radio_button :category, "シングルベンチプレス", class: 'radio radio-primary', disabled: @competition_record.present? %>
           <span class="ml-2"><%= f.label :category, "シングルベンチプレス" %></span>
         </label>
       </div>


### PR DESCRIPTION

## 変更の概要

* 変更の概要
大会情報の編集ページで試技結果登録済のときは
競技種別の編集ができないようにする

* 関連するIssueやプルリクエスト
close #185 

## なぜこの変更をするのか

* 変更をする理由
試技結果登録済みにも関わらず、競技種別の変更
例えば(パワーリフティングからシングルベンチプレス)に
変更すると、IPFポイント の計算地がおかしくなるため。


## やったこと

* [x] 試技結果登録済の大会情報の編集では競技種別のラジオボタンに、`disabled: true`オプションを
追記する
* [x] 大会情報　新規登録のときは`disabled: flase` 選択できる
* [x] 大会情報　更新のとき、試技結果未登録なら`disabled: flase`選択できる
* [x] 大会情報　更新のとき、試技結果登録済みなら`disabled: true`選択不可

