### PR TITLE
add: フラッシュメッセージ(会員登録・ログイン・ログアウト)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
   before_action :set_bottom_navi
+  add_flash_types :success, :danger
 
   private
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -5,14 +5,15 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_to competitions_path
+      redirect_to competitions_path, success: t('.success')
     else
-      render :new
+      flash.now[:danger] = t('.danger')
+      render :new, status: :unprocessable_entity
     end
   end
 
   def destroy
     logout
-    redirect_to root_path, status: :see_other
+    redirect_to root_path, status: :see_other, success: t('.success')
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,10 +8,11 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-	    # 登録が完了したら仮のtopのindex.html.elbへリダイレクト
-      redirect_to root_path
+    # 登録が完了したら仮のtopのindex.html.elbへリダイレクト
+      redirect_to root_path, success: t('.success')
     else
-	    # 登録が失敗したら再度新規登録画面へ
+      flash.now[:danger] = t('.danger')
+    # 登録が失敗したら再度新規登録画面へ
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def flash_background_color(type)
+    case type.to_sym
+    when :success then "bg-green-50 text-green-500"
+    when :danger  then "bg-red-50 text-red-500"
+    else "bg-gray-500 text-black"
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
   def flash_background_color(type)
     case type.to_sym
-    when :success then "bg-green-50 text-green-500"
+    when :success then "bg-green-50 text-green-600"
     when :danger  then "bg-red-50 text-red-500"
     else "bg-gray-500 text-black"
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
       <%= render "shared/before_login_header" %>
     <% end %>
     <!-- ヘッダー -->
+      <%= render "shared/flash_message" %>
       <%= yield %>
     <!-- フッターとボトムナビゲーション -->
     <% if logged_in? %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |message_type, message| %>
+  <div class="rounded-md p-4 text-sm <%= flash_background_color(message_type) %> ">
+    <%= message %>
+  </div>
+<% end %>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -23,6 +23,9 @@ ja:
     new:
       title: ユーザー登録
       to_login_page: ログインページへ
+    create:
+      success: 会員登録が完了しました
+      danger: 会員登録に失敗しました
   competition_record:
     first_attempt: "第1試技"
     second_attempt: "第2試技"

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -13,6 +13,11 @@ ja:
       login: ログイン
       to_register_page: 会員登録ページへ
       password_forget: パスワードをお忘れの方はこちら
+    create:
+      success: ログインしました
+      danger: ログインに失敗しました
+    destroy:
+      success: ログアウトしました
   password_resets:
     new:
       title: パスワードリセット申請


### PR DESCRIPTION
## 機能の概要

* 機能の概要
会員登録時、ログイン、ログアウト時にフラッシュメッセージを出す

* 関連するIssueやプルリクエスト
close #129 

## やったこと
- 新規ユーザー登録
    - [x]  成功：ユーザー登録が完了しました（キー：success　背景色：緑）
    - [x]  失敗：ユーザー登録に失敗しました(キー：danger　背景色：赤）
- ログイン
    - [x]  成功：ログインしました（キー：success　背景色：緑）
    - [x]  失敗：ログインに失敗しました(キー：danger　背景色：赤）
- ログアウト
    - [x]  成功：ログアウトしました（キー：success　背景色：緑）
