### PR TITLE
add: プロフィールの更新時のフラッシュメッセージ

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -11,8 +11,9 @@ class ProfilesController < ApplicationController
   def update
     @user = current_user
     if @user.update(update_user_params)
-      redirect_to profile_path
+      redirect_to profile_path, success: t('.success')
     else
+      flash.now[:danger] = t('.danger')
       render :edit, status: :unprocessable_entity
     end
   end

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -31,6 +31,10 @@ ja:
     create:
       success: 会員登録が完了しました
       danger: 会員登録に失敗しました
+  profiles:
+    update:
+      success: プロフィールの更新が完了しました
+      danger: プロフィールの更新に失敗しました
   competition_record:
     first_attempt: "第1試技"
     second_attempt: "第2試技"


### PR DESCRIPTION
## 機能の概要

* 機能の概要
登録・更新・削除したときの、フラッシュメッセージを出力させる

* 関連するIssueやプルリクエスト
close #191  

## やったこと
プロフィールの更新

- [x]  成功：プロフィールの更新が完了しました（キー：success 　背景色：緑）
- [x]  失敗：プロフィールの更新に失敗しました(キー：danger 　背景色：赤）

