### PR TITLE
add: 大会情報新規登録・更新・削除のフラッシュメッセージを追加

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -15,8 +15,9 @@ class CompetitionsController < ApplicationController
   def create
     @competition = current_user.competitions.build(competition_params)
     if @competition.save
-      redirect_to competitions_path
+      redirect_to competitions_path, success: t('.success')
     else
+      flash.now[:danger] = t('.danger')
       render :new, status: :unprocessable_entity
     end
   end
@@ -38,15 +39,16 @@ class CompetitionsController < ApplicationController
           @competition_result.save!
         end
       end
-      redirect_to competition_path(@competition)
+      redirect_to competition_path(@competition), success: t('.success')
     else
+      flash.now[:danger] = t('.danger')
       render :edit, status: :unprocessable_entity
     end
   end
 
   def destroy
     @competition.destroy!
-    redirect_to competitions_path
+    redirect_to competitions_path, success: t('.success')
   end
 
 private

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -39,6 +39,15 @@ ja:
     update:
       success: プロフィールの更新が完了しました
       danger: プロフィールの更新に失敗しました
+  competitions:
+    create:
+      success: 大会情報を登録しました
+      danger: 大会情報の登録に失敗しました
+    update:
+      success: 大会情報を更新しました
+      danger: 大会情報の更新に失敗しました
+    destroy:
+      success: 大会情報を削除しました
   competition_record:
     first_attempt: "第1試技"
     second_attempt: "第2試技"


### PR DESCRIPTION

## 機能の概要

登録・更新・削除したときの、フラッシュメッセージを出力させる

* 関連するIssueやプルリクエスト
close #195 
## やったこと

- 新規大会情報　登録(create)
  - [x] 成功：大会情報を登録しました（キー：success 　背景色：緑）
  - [x] 失敗：大会情報の登録に失敗しました(キー：danger 　背景色：赤）

- 大会情報　更新(update)
  - [x] 成功：大会情報を更新しました（キー：success 　背景色：緑）
  - [x] 失敗：大会情報の更新に失敗しました(キー：danger 　背景色：赤

- 大会情報　削除(destroy)
  - [x] 成功：大会情報を削除しました（キー：success 　背景色：緑）