### PR TITLE
Feature/#196 flash messe compe records

### DIFF
--- a/app/controllers/competition_records_controller.rb
+++ b/app/controllers/competition_records_controller.rb
@@ -4,7 +4,7 @@ class CompetitionRecordsController < ApplicationController
 
   def destroy
     @competition_record.destroy!
-    redirect_to competition_path(@competition)
+    redirect_to competition_path(@competition), success: t('.success')
   end
 
   private

--- a/app/controllers/record/bench_presses_controller.rb
+++ b/app/controllers/record/bench_presses_controller.rb
@@ -21,11 +21,12 @@ class Record::BenchPressesController < ApplicationController
       })
       case @competition.category
         when "パワーリフティング"
-          redirect_to new_competition_deadlift_path # デッドリフトへ
+          redirect_to new_competition_deadlift_path, success: t('.success') # デッドリフトへ
         when "シングルベンチプレス"
-          redirect_to new_competition_comment_path # コメントへ
+          redirect_to new_competition_comment_path, success: t('.success') # コメントへ
       end
     else
+      flash.now[:danger] = t('.danger')
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/record/bench_presses_controller.rb
+++ b/app/controllers/record/bench_presses_controller.rb
@@ -60,8 +60,9 @@ class Record::BenchPressesController < ApplicationController
       gender = current_user.profile.gender
       # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
       @competition_record.result_save(@competition_record, @competition, gender)
-      redirect_to competition_path(@competition) # 成功したら詳細ページへ遷移する
+      redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
     else
+      flash.now[:danger] = t('.danger')
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/record/comments_controller.rb
+++ b/app/controllers/record/comments_controller.rb
@@ -40,8 +40,9 @@ class Record::CommentsController < ApplicationController
     @comment = Record::Comment.new(comment_params)
     # 取得したレコードのweightの値を、@weigh_in.weightに上書きしてupdateする
     if @competition_record.update(comment: @comment.comment)
-      redirect_to competition_path(@competition) # 成功したら詳細ページへ遷移する
+      redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
     else
+      flash.now[:danger] = t('.danger')
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/record/comments_controller.rb
+++ b/app/controllers/record/comments_controller.rb
@@ -24,8 +24,9 @@ class Record::CommentsController < ApplicationController
       # セッションをクリアにする
       session.delete(:record)
       # 大会結果詳細ページへ遷移
-      redirect_to competition_path(@competition)
+      redirect_to competition_path(@competition), success: t('.success')
     else
+      flash.now[:danger] = t('.danger')
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/record/deadlifts_controller.rb
+++ b/app/controllers/record/deadlifts_controller.rb
@@ -19,8 +19,9 @@ class Record::DeadliftsController < ApplicationController
         deadlift_second_attempt_result: @deadlift.deadlift_second_attempt_result,
         deadlift_third_attempt_result: @deadlift.deadlift_third_attempt_result
       })
-      redirect_to new_competition_comment_path # 次のステップへ遷移
+      redirect_to new_competition_comment_path, success: t('.success') # 次のステップへ遷移
     else
+      flash.now[:danger] = t('.danger')
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/record/deadlifts_controller.rb
+++ b/app/controllers/record/deadlifts_controller.rb
@@ -55,8 +55,9 @@ class Record::DeadliftsController < ApplicationController
       gender = current_user.profile.gender
       # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
       @competition_record.result_save(@competition_record, @competition, gender)
-      redirect_to competition_path(@competition) # 成功したら詳細ページへ遷移する
+      redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
     else
+      flash.now[:danger] = t('.danger')
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/record/squats_controller.rb
+++ b/app/controllers/record/squats_controller.rb
@@ -55,8 +55,9 @@ class Record::SquatsController < ApplicationController
       gender = current_user.profile.gender
       # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
       @competition_record.result_save(@competition_record, @competition, gender)
-      redirect_to competition_path(@competition) # 成功したら詳細ページへ遷移する
+      redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
     else
+      flash.now[:danger] = t('.danger')
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/record/squats_controller.rb
+++ b/app/controllers/record/squats_controller.rb
@@ -19,8 +19,9 @@ class Record::SquatsController < ApplicationController
         squat_second_attempt_result: @squat.squat_second_attempt_result,
         squat_third_attempt_result: @squat.squat_third_attempt_result
       })
-      redirect_to new_competition_bench_presse_path # 次のステップへ遷移
+      redirect_to new_competition_bench_presse_path, success: t('.success') # 次のステップへ遷移
     else
+      flash.now[:danger] = t('.danger')
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/record/weigh_ins_controller.rb
+++ b/app/controllers/record/weigh_ins_controller.rb
@@ -42,8 +42,9 @@ class Record::WeighInsController < ApplicationController
       gender = current_user.profile.gender
       # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
       @competition_record.result_save(@competition_record, @competition, gender)
-      redirect_to competition_path(@competition) # 成功したら詳細ページへ遷移する
+      redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
     else
+      flash.now[:danger] = t('.danger')
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/record/weigh_ins_controller.rb
+++ b/app/controllers/record/weigh_ins_controller.rb
@@ -17,11 +17,12 @@ class Record::WeighInsController < ApplicationController
       }
       case @competition.category
         when "パワーリフティング"
-          redirect_to new_competition_squat_path # スクワットへ
+          redirect_to new_competition_squat_path, success: t('.success') # スクワットへ
         when "シングルベンチプレス"
-          redirect_to new_competition_bench_presse_path # ベンチプレスへ
+          redirect_to new_competition_bench_presse_path, success: t('.success') # ベンチプレスへ
       end
     else
+      flash.now[:danger] = t('.danger')
       render :new, status: :unprocessable_entity
     end
   end

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -7,6 +7,27 @@ ja:
     label:
       email: メールアドレス
       password: パスワード
+  record:
+    weigh_ins:
+      create:
+        success: 検量体重が正しく入力できていることを確認しました
+        danger: 検量体重が正しく入力されていません
+    squats:
+      create:
+        success: 試技結果が正しく入力できていることを確認しました
+        danger: 試技結果が正しく入力されていません
+    bench_presses:
+      create:
+        success: 試技結果が正しく入力できていることを確認しました
+        danger: 試技結果が正しく入力されていません
+    deadlifts:
+      create:
+        success: 試技結果が正しく入力できていることを確認しました
+        danger: 試技結果が正しく入力されていません
+    comments:
+      create:
+        success: 試技結果の登録とトータル重量/IPFポイントの計算が完了しました
+        danger: 試技結果の登録に失敗しました
   user_sessions:
     new:
       title: ログイン

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -12,22 +12,37 @@ ja:
       create:
         success: 検量体重が正しく入力できていることを確認しました
         danger: 検量体重が正しく入力されていません
+      update:
+        success: 検量体重の更新とトータル重量/IPFポイントの計算結果を更新しました
+        danger: 検量体重の更新に失敗しました
     squats:
       create:
         success: 試技結果が正しく入力できていることを確認しました
         danger: 試技結果が正しく入力されていません
+      update:
+        success: スクワットの更新とトータル重量/IPFポイントの計算結果を更新しました
+        danger: スクワットの更新に失敗しました
     bench_presses:
       create:
         success: 試技結果が正しく入力できていることを確認しました
         danger: 試技結果が正しく入力されていません
+      update:
+        success: ベンチプレスの更新とトータル重量/IPFポイントの計算結果を更新しました
+        danger: ベンチプレスの更新に失敗しました
     deadlifts:
       create:
         success: 試技結果が正しく入力できていることを確認しました
         danger: 試技結果が正しく入力されていません
+      update:
+        success: デッドリフトの更新とトータル重量/IPFポイントの計算結果を更新しました
+        danger: デッドリフトの更新に失敗しました
     comments:
       create:
         success: 試技結果の登録とトータル重量/IPFポイントの計算が完了しました
         danger: 試技結果の登録に失敗しました
+      update:
+        success: コメントの更新をしました
+        danger: コメントの更新に失敗しました
   user_sessions:
     new:
       title: ログイン
@@ -69,6 +84,9 @@ ja:
       danger: 大会情報の更新に失敗しました
     destroy:
       success: 大会情報を削除しました
+  competition_records:
+    destroy:
+      success: 試技結果を削除しました
   competition_record:
     first_attempt: "第1試技"
     second_attempt: "第2試技"


### PR DESCRIPTION
## 機能の概要

試技結果の、更新、登録、削除のフラッシュメッセージ
close #196 

## やったこと
### 試技結果　登録完了
path:  `Record::CommentsController/create`
  - [x] 成功：試技結果の登録とトータル重量/IPFポイントの計算が完了しました（キー：success 　背景色：緑）
  - [x] 失敗：試技結果の登録に失敗しました(キー：danger 　背景色：赤）

### 検量体重～各試技結果　登録完了
path:  `Record::WeighInssController/create～Record::(種目)Controller/create`
  - [x] 成功：～～が正しく入力できていることを確認しました。（キー：success 　背景色：緑）
  - [x] 失敗：～～が正しく入力されていません(キー：danger 　背景色：赤）


### 検量体重～各試技結果　更新完了(update)
path:  `Record::WeighInssController/update～Record::(種目)Controller/update`
  - [x] 成功：～～の更新とトータル重量/IPFポイントの計算結果を更新しました（キー：success 　背景色：緑）
  - [x] 失敗：～～の更新に失敗しました(キー：danger 　背景色：赤

### コメント　更新完了(update)
path:  `Record::CommentsController/update`
  - [x] 成功：～～を更新しました（キー：success 　背景色：緑）
  - [x] 失敗：～～の更新に失敗しました(キー：danger 　背景色：赤
  

###  試技結果　全削除(destroy)
path: `CompetitionRecordsController/destroy`
  - [x] 成功：試技結果を削除しました（キー：success 　背景色：緑）

