### PR TITLE
update: 大会結果一覧ページのレイアウトを変更

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1,6 +1,7 @@
 class Competition < ApplicationRecord
   belongs_to :user
   has_one :competition_record, dependent: :destroy
+  has_one :competition_result, through: :competition_record
 
   validates :name, presence: true, length: { maximum: 255 }
   validates :venue, length: { maximum: 255 }
@@ -31,4 +32,47 @@ class Competition < ApplicationRecord
     ]
   }.freeze
 
+  def best_squat_weight_result(competition)
+    competition&.competition_record&.competition_result&.best_squat_weight
+  end
+
+  def best_benchpress_weight_result(competition)
+    competition&.competition_record&.competition_result&.best_benchpress_weight
+  end
+
+  def best_deadlift_weight_result(competition)
+    competition&.competition_record&.competition_result&.best_deadlift_weight
+  end
+
+  def total_lifted_weight_result(competition)
+    competition&.competition_record&.competition_result&.total_lifted_weight
+  end
+
+  def ipf_points_result(competition)
+    competition&.competition_record&.competition_result&.ipf_points
+  end
+
+  def first_benchpress_result(competition)
+    competition&.competition_record&.benchpress_first_attempt
+  end
+
+  def second_benchpress_result(competition)
+    competition&.competition_record&.benchpress_second_attempt
+  end
+
+  def third_benchpress_result(competition)
+    competition&.competition_record&.benchpress_third_attempt
+  end
+
+  def benchpress_first_attempt_failure?(competition)
+    competition&.competition_record&.benchpress_first_attempt_result == "failure"
+  end
+
+  def benchpress_second_attempt_failure?(competition)
+    competition&.competition_record&.benchpress_second_attempt_result == "failure"
+  end
+
+  def benchpress_third_attempt_failure?(competition)
+    competition&.competition_record&.benchpress_third_attempt_result == "failure"
+  end
 end

--- a/app/views/competitions/_benchpress_result.erb
+++ b/app/views/competitions/_benchpress_result.erb
@@ -1,0 +1,16 @@
+<div class = "mr-1">
+  <div class="text-sm text-red-500">MAX</div>
+  <div class="text-xl font-bold text-red-500"><%= competition.total_lifted_weight_result(competition) %>kg</div>
+</div>
+<div class="text-center">
+  <div class="text-sm text-gray-500">1st</div>
+  <div class="text-base font-bold <%= 'line-through' if competition.benchpress_first_attempt_failure?(competition) %>"><%= competition.first_benchpress_result(competition) %>kg</div>
+</div>
+<div class="text-center">
+  <div class="text-sm text-gray-500">2st</div>
+  <div class="text-base font-bold <%= 'line-through' if competition.benchpress_second_attempt_failure?(competition) %>"><%= competition.second_benchpress_result(competition) %>kg</div>
+</div>
+<div class="text-center">
+  <div class="text-sm text-gray-500">3rd</div>
+  <div class="text-base font-bold <%= 'line-through' if competition.benchpress_third_attempt_failure?(competition) %>"><%= competition.third_benchpress_result(competition) %>kg </div>
+</div>

--- a/app/views/competitions/_competition.html.erb
+++ b/app/views/competitions/_competition.html.erb
@@ -14,24 +14,20 @@
         </div>
       </div>
     </div>
-    <div class="p-4">
+    <div class="p-4 h-20">
       <div class="flex items-center justify-between">
+      <% unless competition.competition_record.present? %>
         <div class = "mr-1">
-          <div class="text-sm text-red-500">TOTAL</div>
-          <div class="text-xl font-bold text-red-500"><%= competition.total_lifted_weight_result(competition) %>kg</div>
+          <div class="text-base  text-left font-bold">試技結果が未登録です</div>
         </div>
-        <div class="text-center">
-          <div class="text-sm text-gray-500">SQ</div>
-          <div class="text-base font-bold"><%= competition.best_squat_weight_result(competition) %>kg</div>
-        </div>
-        <div class="text-center">
-          <div class="text-sm text-gray-500">BP</div>
-          <div class="text-base font-bold"><%= competition.best_benchpress_weight_result(competition) %>kg</div>
-        </div>
-        <div class="text-center">
-          <div class="text-sm text-gray-500">DL</div>
-          <div class="text-base font-bold"><%= competition.best_deadlift_weight_result(competition) %>kg </div>
-        </div>
+      <% else %>
+        <% if competition.category == "パワーリフティング" %>
+          <%= render 'powerlifting_result', competition: competition %>
+        <% end %>
+        <% if competition.category == "シングルベンチプレス" %>
+          <%= render 'benchpress_result', competition: competition %>
+        <% end %>
+      <% end %>
       </div>
     </div>
   </div>

--- a/app/views/competitions/_competition.html.erb
+++ b/app/views/competitions/_competition.html.erb
@@ -1,10 +1,37 @@
-
-    <tbody class="divide-y divide-gray-100 border-t border-gray-100 text-xs">
-      <tr class="hover:bg-gray-50">
-        <td class="text-left px-4 py-4 text-gray-900"><%= competition.date %></td>
-        <td class="text-left px-4 py-4 w-48"><%= competition.name %></td>
-        <td class="px-4 py-4">
-          <%= link_to "詳細", competition_path(competition), class: "btn btn-sm text-xs" %>
-        </td>
-      </tr>
-    </tbody>
+  <div class="mx-auto max-w-80 min-w-80 rounded-lg bg-white shadow my-4 border-2 border-red-500/50">
+    <div class="p-4 border-b border-gray-200">
+      <div class="flex items-center justify-left">
+        <span class="text-sm font-medium text-red-500 mr-2"><%= competition.competition_type_i18n %></span>
+        <span class="text-sm font-medium text-red-500 mr-auto"><%= competition.category %></span>
+        <%= link_to "詳細", competition_path(competition), class: "btn btn-sm btn-outline btn-primary" %>
+      </div>
+      <div class="flex flex-col place-items-start">
+        <div class="mt-1 text-sm text-gray-500"><%= competition.date %></div>
+        <div class="mt-1 text-base  text-left font-bold truncate w-full"><%= competition.name %></div>
+        <div class="mt-1 flex items-center justify-left">
+          <span class="text-sm text-gray-500 mr-2"><%= competition.weight_class %></span>
+          <span class="text-sm text-gray-500 "><%= competition.gearcategory_type_i18n %></span>
+        </div>
+      </div>
+    </div>
+    <div class="p-4">
+      <div class="flex items-center justify-between">
+        <div class = "mr-1">
+          <div class="text-sm text-red-500">TOTAL</div>
+          <div class="text-xl font-bold text-red-500"><%= competition.total_lifted_weight_result(competition) %>kg</div>
+        </div>
+        <div class="text-center">
+          <div class="text-sm text-gray-500">SQ</div>
+          <div class="text-base font-bold"><%= competition.best_squat_weight_result(competition) %>kg</div>
+        </div>
+        <div class="text-center">
+          <div class="text-sm text-gray-500">BP</div>
+          <div class="text-base font-bold"><%= competition.best_benchpress_weight_result(competition) %>kg</div>
+        </div>
+        <div class="text-center">
+          <div class="text-sm text-gray-500">DL</div>
+          <div class="text-base font-bold"><%= competition.best_deadlift_weight_result(competition) %>kg </div>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/app/views/competitions/_powerlifting_result.html.erb
+++ b/app/views/competitions/_powerlifting_result.html.erb
@@ -1,0 +1,16 @@
+<div class = "mr-1">
+  <div class="text-sm text-red-500">TOTAL</div>
+  <div class="text-xl font-bold text-red-500"><%= competition.total_lifted_weight_result(competition) %>kg</div>
+</div>
+<div class="text-center">
+  <div class="text-sm text-gray-500">SQ</div>
+  <div class="text-base font-bold"><%= competition.best_squat_weight_result(competition) %>kg</div>
+</div>
+<div class="text-center">
+  <div class="text-sm text-gray-500">BP</div>
+  <div class="text-base font-bold"><%= competition.best_benchpress_weight_result(competition) %>kg</div>
+</div>
+<div class="text-center">
+  <div class="text-sm text-gray-500">DL</div>
+  <div class="text-base font-bold"><%= competition.best_deadlift_weight_result(competition) %>kg </div>
+</div>

--- a/app/views/competitions/index.html.erb
+++ b/app/views/competitions/index.html.erb
@@ -1,40 +1,5 @@
 <div class="mx-auto w-full max-w-screen-sm text-center">
     <!-- 大会結果一覧 -->
   <h1 class="text-2xl">出場済大会の一覧</h1>
-  <div class="mx-auto max-w-80 min-w-80 rounded-lg bg-white shadow my-4 border-2 border-red-500/50">
-    <div class="p-4 border-b border-gray-200">
-      <div class="flex items-center justify-left">
-        <span class="text-sm font-medium text-red-500 mr-2">非公式</span>
-        <span class="text-sm font-medium text-red-500 mr-auto">シングルベンチプレス</span>
-        <button class="btn btn-sm btn-outline btn-primary">詳細</button>
-      </div>
-      <div class="flex flex-col place-items-start">
-        <div class="mt-1 text-sm text-gray-500">2024/10/30</div>
-        <div class="mt-1 text-base  text-left font-bold truncate w-full">第76回東京都パワーリフティング春季大会ああああああああああああああ</div>
-        <div class="mt-1 flex items-center justify-left">
-          <span class="text-sm text-gray-500 mr-2">女子47kg級</span>
-          <span class="text-sm text-gray-500 ">ノーギア</span>
-        </div>
-      </div>
-    </div>
-    <div class="p-4">
-      <div class="flex items-center justify-between">
-        <div class = "mr-1">
-          <div class="text-sm text-red-500">TOTAL</div>
-          <div class="text-xl font-bold text-red-500">300.0kg</div>
-        </div>
-        <div class="text-center">
-          <div class="text-sm text-gray-500">SQ</div>
-          <div class="text-base font-bold">100.0kg</div>
-        </div>
-        <div class="text-center">
-          <div class="text-sm text-gray-500">BP</div>
-          <div class="text-base font-bold">100.0kg</div>
-        </div>
-        <div class="text-center">
-          <div class="text-sm text-gray-500">DL</div>
-          <div class="text-base font-bold">100.0kg</div>
-        </div>
-      </div>
-  </div>
+  <%= render @competitions %>
 </div>

--- a/app/views/competitions/index.html.erb
+++ b/app/views/competitions/index.html.erb
@@ -1,22 +1,40 @@
-<div class="hero min-h-screen bg-base-200 pb-16">
-  <div class="hero-content flex-col">
-      <!-- 大会結果一覧 -->
-    <h1 class="text-2xl">出場済大会の一覧</h1>
-    <div class="w-full mx-auto max-w-full overflow-auto">
-      <table class="border-collapse table-auto bg-white text-center text-sm text-gray-500">
-        <thead class="bg-gray-50">
-          <tr>
-            <th scope="col" class="px-4 py-4 font-medium text-gray-900"><%= Competition.human_attribute_name("date") %></th>
-            <th scope="col" class="px-4 py-4 font-medium text-gray-900 w-48"><%= Competition.human_attribute_name("name") %></th>
-            <th scope="col" class="px-4 py-4 font-medium text-gray-900"></th>
-          </tr>
-        </thead>
-        <% if @competitions.present? %>
-          <%= render @competitions %>
-        <% else %>
-          <p>存在しません</p>
-        <% end %>
-      </table>
+<div class="mx-auto w-full max-w-screen-sm text-center">
+    <!-- 大会結果一覧 -->
+  <h1 class="text-2xl">出場済大会の一覧</h1>
+  <div class="mx-auto max-w-80 min-w-80 rounded-lg bg-white shadow my-4 border-2 border-red-500/50">
+    <div class="p-4 border-b border-gray-200">
+      <div class="flex items-center justify-left">
+        <span class="text-sm font-medium text-red-500 mr-2">非公式</span>
+        <span class="text-sm font-medium text-red-500 mr-auto">シングルベンチプレス</span>
+        <button class="btn btn-sm btn-outline btn-primary">詳細</button>
+      </div>
+      <div class="flex flex-col place-items-start">
+        <div class="mt-1 text-sm text-gray-500">2024/10/30</div>
+        <div class="mt-1 text-base  text-left font-bold truncate w-full">第76回東京都パワーリフティング春季大会ああああああああああああああ</div>
+        <div class="mt-1 flex items-center justify-left">
+          <span class="text-sm text-gray-500 mr-2">女子47kg級</span>
+          <span class="text-sm text-gray-500 ">ノーギア</span>
+        </div>
+      </div>
     </div>
+    <div class="p-4">
+      <div class="flex items-center justify-between">
+        <div class = "mr-1">
+          <div class="text-sm text-red-500">TOTAL</div>
+          <div class="text-xl font-bold text-red-500">300.0kg</div>
+        </div>
+        <div class="text-center">
+          <div class="text-sm text-gray-500">SQ</div>
+          <div class="text-base font-bold">100.0kg</div>
+        </div>
+        <div class="text-center">
+          <div class="text-sm text-gray-500">BP</div>
+          <div class="text-base font-bold">100.0kg</div>
+        </div>
+        <div class="text-center">
+          <div class="text-sm text-gray-500">DL</div>
+          <div class="text-base font-bold">100.0kg</div>
+        </div>
+      </div>
   </div>
 </div>


### PR DESCRIPTION
## 変更の概要

* 変更の概要
大会結果一覧ページを、表形式からカード形式に変更した

* 関連するIssueやプルリクエスト
close #138 

## なぜこの変更をするのか

* 変更をする理由
  - 表形式だと、スマホサイズでみたときに表示できる情報に制限がある
  (開催日、大会名しか表示できませんでした)
  - カード形式にすることで、大会の詳細を観に行かなくても一覧表示だけで
  主要な情報が取得できる画面にした

## やったこと
カード型UIにして以下の内容がわかるようにする
- [x] 公式・非公式
- [x] パワーかシングルベンチか
- [x] 日付
- [x] 大会名
- [x] 階級
- [x] フルギアかノーギアか
- [x] 合計重量
- [x] 各試技の最高重量

- [x]  パワーリフティング用パーシャル
  - `_powerlifting.html.erb `
  
- [x] ベンチプレス用パーシャル
  - `_benchpress.html.erb`
 

- [x] まだ試技結果登録していないとき
  - 試技結果の登録がありません


## 変更内容
### 変更前
[![Image from Gyazo](https://i.gyazo.com/23d6fef616ee454452827f143c9d8ba9.png)](https://gyazo.com/23d6fef616ee454452827f143c9d8ba9)
### 変更後
[![Image from Gyazo](https://i.gyazo.com/5b38c7501c3585900da3a2f551b7b134.png)](https://gyazo.com/5b38c7501c3585900da3a2f551b7b134)

## 課題
### 今後付け足したい事
- 検索機能  #155 
- タブでパワーリフティング、シングルベンチ、公式、非公式の切り替えをできるようにしたい #202
