### PR TITLE
add: 試技結果の新規登録と更新時にバリデーションを追加

### DIFF
--- a/app/models/competition_record.rb
+++ b/app/models/competition_record.rb
@@ -57,6 +57,19 @@ class CompetitionRecord < ApplicationRecord
   validate :deadlift_first_attempt_is_not_be_not_attempted
   validate :deadlift_second_attempt_is_not_be_not_attempted
   validate :deadlift_third_attempt_is_not_be_not_attempted
+  # 成功か失敗選択時に重量が入力されていない
+  # スクワット
+  validate :squat_first_attempt_is_not_be_blank
+	validate :squat_second_attempt_is_not_be_blank
+	validate :squat_third_attempt_is_not_be_blank
+  # ベンチプレス
+  validate :benchpress_first_attempt_is_not_be_blank
+	validate :benchpress_second_attempt_is_not_be_blank
+	validate :benchpress_third_attempt_is_not_be_blank
+  # デッドリフト
+  validate :deadlift_first_attempt_is_not_be_blank
+	validate :deadlift_second_attempt_is_not_be_blank
+	validate :deadlift_third_attempt_is_not_be_blank
 
   # カスタムバリデータ　スクワット判定結果
   def squat_first_attempt_is_not_be_not_attempted
@@ -114,6 +127,64 @@ class CompetitionRecord < ApplicationRecord
       errors.add(:deadlift_third_attempt_result, "は成功か失敗かを選んでください")
     end
   end
+  # 成功か失敗選択時に重量が入力されていない
+  # スクワット
+  def squat_first_attempt_is_not_be_blank
+		if (squat_first_attempt_result == "success" || squat_first_attempt_result == "failure") && squat_first_attempt.blank?
+			errors.add(:squat_first_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
+
+	def squat_second_attempt_is_not_be_blank
+		if (squat_second_attempt_result == "success" || squat_second_attempt_result == "failure") && squat_second_attempt.blank?
+			errors.add(:squat_second_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
+
+	def squat_third_attempt_is_not_be_blank
+		if (squat_third_attempt_result == "success" || squat_third_attempt_result == "failure") && squat_third_attempt.blank?
+			errors.add(:squat_third_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
+  # 成功か失敗選択時に重量が入力されていない
+  # ベンチプレス
+  def benchpress_first_attempt_is_not_be_blank
+		if (benchpress_first_attempt_result == "success" || benchpress_first_attempt_result == "failure") && benchpress_first_attempt.blank?
+			errors.add(:benchpress_first_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
+
+	def benchpress_second_attempt_is_not_be_blank
+		if (benchpress_second_attempt_result == "success" || benchpress_second_attempt_result == "failure") && benchpress_second_attempt.blank?
+			errors.add(:benchpress_second_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
+
+	def benchpress_third_attempt_is_not_be_blank
+		if (benchpress_third_attempt_result == "success" || benchpress_third_attempt_result == "failure") && benchpress_third_attempt.blank?
+			errors.add(:benchpress_third_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
+
+  # 成功か失敗選択時に重量が入力されていない
+  # デッドリフト
+  def deadlift_first_attempt_is_not_be_blank
+		if (deadlift_first_attempt_result == "success" || deadlift_first_attempt_result == "failure") && deadlift_first_attempt.blank?
+			errors.add(:deadlift_first_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
+
+	def deadlift_second_attempt_is_not_be_blank
+		if (deadlift_second_attempt_result == "success" || deadlift_second_attempt_result == "failure") && deadlift_second_attempt.blank?
+			errors.add(:deadlift_second_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
+
+	def deadlift_third_attempt_is_not_be_blank
+		if (deadlift_third_attempt_result == "success" || deadlift_third_attempt_result == "failure") && deadlift_third_attempt.blank?
+			errors.add(:deadlift_third_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
 
   def result_save(competition_record, competition, gender)
     ActiveRecord::Base.transaction do

--- a/app/models/record/bench_press.rb
+++ b/app/models/record/bench_press.rb
@@ -39,6 +39,11 @@ class Record::BenchPress
 	validate :benchpress_second_attempt_is_not_be_not_attempted, unless: :should_validate_benchpress_second_attempt_numericality?
 	validate :benchpress_third_attempt_is_not_be_not_attempted, unless: :should_validate_benchpress_third_attempt_numericality?
 
+	# 成功か失敗選択時に重量が入力されていない
+	validate :benchpress_first_attempt_is_not_be_blank
+	validate :benchpress_second_attempt_is_not_be_blank
+	validate :benchpress_third_attempt_is_not_be_blank
+
 	private
 	# 重量の入力フォームに文字列が入力されていないか？
 	# 第一試技
@@ -71,6 +76,25 @@ class Record::BenchPress
 	def benchpress_third_attempt_is_not_be_not_attempted
 		if benchpress_third_attempt.present? && Float(benchpress_third_attempt, exception: false) >= 0 && benchpress_third_attempt_result == "not_attempted"
 			errors.add(:benchpress_third_attempt_result, "は成功か失敗かを選んでください")
+		end
+	end
+	# 成功か失敗選択時に重量が入力されていない
+  # ベンチプレス
+  def benchpress_first_attempt_is_not_be_blank
+		if (benchpress_first_attempt_result == "success" || benchpress_first_attempt_result == "failure") && benchpress_first_attempt.blank?
+			errors.add(:benchpress_first_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
+
+	def benchpress_second_attempt_is_not_be_blank
+		if (benchpress_second_attempt_result == "success" || benchpress_second_attempt_result == "failure") && benchpress_second_attempt.blank?
+			errors.add(:benchpress_second_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
+
+	def benchpress_third_attempt_is_not_be_blank
+		if (benchpress_third_attempt_result == "success" || benchpress_third_attempt_result == "failure") && benchpress_third_attempt.blank?
+			errors.add(:benchpress_third_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
 		end
 	end
 end

--- a/app/models/record/deadlift.rb
+++ b/app/models/record/deadlift.rb
@@ -39,6 +39,11 @@ class Record::Deadlift
 	validate :deadlift_second_attempt_is_not_be_not_attempted, unless: :should_validate_deadlift_second_attempt_numericality?
 	validate :deadlift_third_attempt_is_not_be_not_attempted, unless: :should_validate_deadlift_third_attempt_numericality?
 
+	# 成功か失敗選択時に重量が入力されていない
+	validate :deadlift_first_attempt_is_not_be_blank
+	validate :deadlift_second_attempt_is_not_be_blank
+	validate :deadlift_third_attempt_is_not_be_blank
+
 	private
 	# 重量の入力フォームに文字列が入力されていないか？
 	# 第一試技
@@ -71,6 +76,26 @@ class Record::Deadlift
 	def deadlift_third_attempt_is_not_be_not_attempted
 		if deadlift_third_attempt.present? && Float(deadlift_third_attempt, exception: false) >= 0 && deadlift_third_attempt_result == "not_attempted"
 			errors.add(:deadlift_third_attempt_result, "は成功か失敗かを選んでください")
+		end
+	end
+
+	# 成功か失敗選択時に重量が入力されていない
+  # デッドリフト
+  def deadlift_first_attempt_is_not_be_blank
+		if (deadlift_first_attempt_result == "success" || deadlift_first_attempt_result == "failure") && deadlift_first_attempt.blank?
+			errors.add(:deadlift_first_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
+
+	def deadlift_second_attempt_is_not_be_blank
+		if (deadlift_second_attempt_result == "success" || deadlift_second_attempt_result == "failure") && deadlift_second_attempt.blank?
+			errors.add(:deadlift_second_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
+
+	def deadlift_third_attempt_is_not_be_blank
+		if (deadlift_third_attempt_result == "success" || deadlift_third_attempt_result == "failure") && deadlift_third_attempt.blank?
+			errors.add(:deadlift_third_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
 		end
 	end
 end

--- a/app/models/record/squat.rb
+++ b/app/models/record/squat.rb
@@ -38,6 +38,11 @@ class Record::Squat
 	validate :squat_first_attempt_is_not_be_not_attempted, unless: :should_validate_squat_first_attempt_numericality?
 	validate :squat_second_attempt_is_not_be_not_attempted, unless: :should_validate_squat_second_attempt_numericality?
 	validate :squat_third_attempt_is_not_be_not_attempted, unless: :should_validate_squat_third_attempt_numericality?
+	# 成功か失敗選択時に重量が入力されていない
+	# スクワット
+	validate :squat_first_attempt_is_not_be_blank
+	validate :squat_second_attempt_is_not_be_blank
+	validate :squat_third_attempt_is_not_be_blank
 
 	private
 	# 重量の入力フォームに文字列が入力されていないか？
@@ -73,4 +78,24 @@ class Record::Squat
 			errors.add(:squat_third_attempt_result, "は成功か失敗かを選んでください")
 		end
 	end
+	# カスタムバリデータ 成功か失敗選択時に重量が入力されていない
+	# 第一試技
+	def squat_first_attempt_is_not_be_blank
+		if (squat_first_attempt_result == "success" || squat_first_attempt_result == "failure") && squat_first_attempt.blank?
+			errors.add(:squat_first_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
+	# 第二試技
+	def squat_second_attempt_is_not_be_blank
+		if (squat_second_attempt_result == "success" || squat_second_attempt_result == "failure") && squat_second_attempt.blank?
+			errors.add(:squat_second_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
+	# 第三試技
+	def squat_third_attempt_is_not_be_blank
+		if (squat_third_attempt_result == "success" || squat_third_attempt_result == "failure") && squat_third_attempt.blank?
+			errors.add(:squat_third_attempt, "は成功か失敗を選択したときは重量を入力して下さい。")
+		end
+	end
+
 end


### PR DESCRIPTION

## 変更の概要

* 変更の概要
試技結果新規登録時と、更新にて
試技判定結果が成功か失敗か選択しているとき
重量値が入力されていないまま送信ボタン押したらバリデーションエラーになるようにした。


* 関連するIssueやプルリクエスト
　close #160 
## なぜこの変更をするのか

* 変更をする理由
試技計算式の変数に、nillが代入されるのでエラーがでる


## やったこと

- [x] 新規登録時のモデルファイルにカスタムバリデータ追加
- [x] 更新時のモデルファイル(competition_record)にカスタムバリデータ追加
- [x]  バリデーションが実行され、「~~は成功か失敗を選択したときは重量を入力して下さい。」のエラーメッセージが出る事を確認
