### PR TITLE
fix: ボトムナビゲーションの表示をcreateアクションとupdateアクションでさせない

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,4 +12,8 @@ class ApplicationController < ActionController::Base
   def set_bottom_navi
 	  @show_bottom_nav = true
   end
+
+  def hide_bottom_navi
+    @show_bottom_nav = false
+  end
 end

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -3,6 +3,7 @@ class CompetitionsController < ApplicationController
   before_action :set_competition_record, only: %i[ show edit update ]
   before_action :set_competition_result, only: %i[ show update ]
   skip_before_action :set_bottom_navi, only: %i[ new edit ]
+  before_action :hide_bottom_navi, only: %i[ create update ]
 
   def index
     @competitions = current_user.competitions.order(date: :desc)

--- a/app/controllers/record/bench_presses_controller.rb
+++ b/app/controllers/record/bench_presses_controller.rb
@@ -3,6 +3,7 @@ class Record::BenchPressesController < ApplicationController
   before_action :set_competition_record, only: %i[ edit update ]
   before_action :set_competition_result, only: %i[ update ]
   skip_before_action :set_bottom_navi, only: %i[ new edit ]
+  before_action :hide_bottom_navi, only: %i[ create update ]
 
   def new
     @bench_press = Record::BenchPress.new

--- a/app/controllers/record/comments_controller.rb
+++ b/app/controllers/record/comments_controller.rb
@@ -2,6 +2,7 @@ class Record::CommentsController < ApplicationController
   before_action :set_competition
   before_action :set_competition_record, only: %i[ edit update ]
   skip_before_action :set_bottom_navi, only: %i[ new edit ]
+  before_action :hide_bottom_navi, only: %i[ create update ]
 
   def new
     @comment = Record::Comment.new

--- a/app/controllers/record/deadlifts_controller.rb
+++ b/app/controllers/record/deadlifts_controller.rb
@@ -3,6 +3,7 @@ class Record::DeadliftsController < ApplicationController
   before_action :set_competition_record, only: %i[ edit update ]
   before_action :set_competition_result, only: %i[ update ]
   skip_before_action :set_bottom_navi, only: %i[ new edit ]
+  before_action :hide_bottom_navi, only: %i[ create update ]
 
   def new
     @deadlift = Record::Deadlift.new

--- a/app/controllers/record/squats_controller.rb
+++ b/app/controllers/record/squats_controller.rb
@@ -3,6 +3,7 @@ class Record::SquatsController < ApplicationController
   before_action :set_competition_record, only: %i[ edit update ]
   before_action :set_competition_result, only: %i[ update ]
   skip_before_action :set_bottom_navi, only: %i[ new edit ]
+  before_action :hide_bottom_navi, only: %i[ create update ]
 
   def new
     @squat = Record::Squat.new

--- a/app/controllers/record/weigh_ins_controller.rb
+++ b/app/controllers/record/weigh_ins_controller.rb
@@ -3,6 +3,7 @@ class Record::WeighInsController < ApplicationController
   before_action :set_competition_record, only: %i[ edit update ]
   before_action :set_competition_result, only: %i[ update ]
   skip_before_action :set_bottom_navi, only: %i[ new edit ]
+  before_action :hide_bottom_navi, only: %i[ create update ]
 
   def new
     @weigh_in = Record::WeighIn.new


### PR DESCRIPTION
## 変更の概要

* 変更の概要
登録ページ、編集ページでボトムナビゲーションを非表示にしていたが、
データの保存に失敗してrenderで再レンダリングしたときもボトムナビゲーションが
表示されないようにした。

* 関連するIssueやプルリクエスト
close #211

## なぜこの変更をするのか

* 変更をする理由
ボトムナビゲーションが、入力ページでも下部にあると
誤操作に繋がる懸念があるため。
表示させたくないため。
