### PR TITLE
add: 未来の日付を選択できないようにした

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -12,6 +12,7 @@ class Competition < ApplicationRecord
   validates :age_group, presence: true
   validates :weight_class, presence: true
   validates :participation_status, presence: true
+  validate  :date_is_not_future
 
   # enum定義
   enum competition_type: { official: 0, unofficial: 1 } # 大会種別：公式大会、非公式大会
@@ -85,5 +86,13 @@ class Competition < ApplicationRecord
 
   def benchpress_third_attempt_failure?(competition)
     competition&.competition_record&.benchpress_third_attempt_result == "failure"
+  end
+
+  private
+
+  def date_is_not_future
+    if date.present? && date > Date.today
+      errors.add(:date, "は本日含む過去の日付を入力してください") 
+    end
   end
 end

--- a/app/views/competitions/_form.html.erb
+++ b/app/views/competitions/_form.html.erb
@@ -22,7 +22,7 @@
       <%= f.label :date, class: 'mr-2 font-semibold' %>
       <p class="text-red-500">(必須)</p>
     </div>
-      <%= f.date_field :date, class: 'input input-bordered input-sm rounded w-full max-w-xs text-base', placeholder:"開催日" %>
+      <%= f.date_field :date, class: 'input input-bordered input-sm rounded w-full max-w-xs text-base', placeholder:"開催日", max: Date.today%>
       <%= render 'shared/error_messages', object: f.object, attribute: :date %>
   </label>
   <!-- ここから選択制 -->


### PR DESCRIPTION

## 変更の概要

* 変更の概要
大会情報の記録・編集するとき未来の日付を入力できないように
制限をかけた

* 関連するIssueやプルリクエスト
close #208

## なぜこの変更をするのか

* 変更をする理由

誤って、未来の日付を登録してしまったとき、`participation_status` カラムの
ステータスと矛盾が発生してしまうため。
現状、デフォルトで`participation_status` カラムには「出場済」ステータスになっている。

※ 今後実装予定の「出場予定の大会記録機能」で、ユーザーの入力した日付から判定して
`participation_status` カラムのステータスを「出場予定」に自動切り替えします。


## やったこと

* [x] 日付入力フォームに、max: Date,today を記述し、ユーザーが今日より未来の日付を選択できないようにした
* [x] カスタムバリデータを設定した

## 備考

出場予定大会記録の issue #14 で条件によってはこのバリデーションを解除します