### PR TITLE
add: 成績グラフ機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,9 @@ gem 'dotenv-rails'
 # LINEBot(Line messaging API用)
 gem 'line-bot-api'
 
+# グラフ描写用
+gem "chartkick"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chartkick (5.0.7)
     childprocess (5.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
@@ -293,6 +294,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   capybara
+  chartkick
   config
   cssbundling-rails
   debug

--- a/app/controllers/charts_controller.rb
+++ b/app/controllers/charts_controller.rb
@@ -1,0 +1,4 @@
+class ChartsController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/charts_helper.rb
+++ b/app/helpers/charts_helper.rb
@@ -1,0 +1,2 @@
+module ChartsHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "chartkick/chart.js"

--- a/app/queries/classic_powerlifting_ipfglpoints_query.rb
+++ b/app/queries/classic_powerlifting_ipfglpoints_query.rb
@@ -1,5 +1,5 @@
 class ClassicPowerliftingIpfglpointsQuery < Query
-	def initialize(user)
+  def initialize(user)
     @user = user
   end
 

--- a/app/queries/classic_powerlifting_ipfglpoints_query.rb
+++ b/app/queries/classic_powerlifting_ipfglpoints_query.rb
@@ -1,5 +1,4 @@
 class ClassicPowerliftingIpfglpointsQuery < Query
-
 	def initialize(user)
     @user = user
   end

--- a/app/queries/classic_powerlifting_ipfglpoints_query.rb
+++ b/app/queries/classic_powerlifting_ipfglpoints_query.rb
@@ -1,0 +1,14 @@
+class ClassicPowerliftingIpfglpointsQuery < Query
+
+	def initialize(user)
+    @user = user
+  end
+
+  def call
+    QueryBuilder.new(@user)
+      .with_competition_type(0)
+      .with_gearcategory_type(0)
+      .with_category("パワーリフティング")
+      .pluck_values("competition_results.ipf_points")
+  end
+end

--- a/app/queries/classic_powerlifting_total_lifted_weight_query.rb
+++ b/app/queries/classic_powerlifting_total_lifted_weight_query.rb
@@ -1,0 +1,14 @@
+class ClassicPowerliftingTotalLiftedWeightQuery < Query
+
+	def initialize(user)
+    @user = user
+  end
+
+  def call
+    QueryBuilder.new(@user)
+      .with_competition_type(0)
+      .with_gearcategory_type(0)
+      .with_category("パワーリフティング")
+      .pluck_values("competition_results.total_lifted_weight")
+  end
+end

--- a/app/queries/classic_powerlifting_total_lifted_weight_query.rb
+++ b/app/queries/classic_powerlifting_total_lifted_weight_query.rb
@@ -1,5 +1,4 @@
 class ClassicPowerliftingTotalLiftedWeightQuery < Query
-
 	def initialize(user)
     @user = user
   end

--- a/app/queries/classic_powerlifting_total_lifted_weight_query.rb
+++ b/app/queries/classic_powerlifting_total_lifted_weight_query.rb
@@ -1,5 +1,5 @@
 class ClassicPowerliftingTotalLiftedWeightQuery < Query
-	def initialize(user)
+  def initialize(user)
     @user = user
   end
 

--- a/app/queries/classic_single_bench_press_ipfglpoints_query.rb
+++ b/app/queries/classic_single_bench_press_ipfglpoints_query.rb
@@ -1,5 +1,4 @@
 class ClassicSingleBenchPressIpfglpointsQuery < Query
-
 	def initialize(user)
     @user = user
   end

--- a/app/queries/classic_single_bench_press_ipfglpoints_query.rb
+++ b/app/queries/classic_single_bench_press_ipfglpoints_query.rb
@@ -1,0 +1,14 @@
+class ClassicSingleBenchPressIpfglpointsQuery < Query
+
+	def initialize(user)
+    @user = user
+  end
+
+  def call
+    QueryBuilder.new(@user)
+      .with_competition_type(0)
+      .with_gearcategory_type(0)
+      .with_category("シングルベンチプレス")
+      .pluck_values("competition_results.ipf_points")
+  end
+end

--- a/app/queries/classic_single_bench_press_ipfglpoints_query.rb
+++ b/app/queries/classic_single_bench_press_ipfglpoints_query.rb
@@ -1,5 +1,5 @@
 class ClassicSingleBenchPressIpfglpointsQuery < Query
-	def initialize(user)
+  def initialize(user)
     @user = user
   end
 

--- a/app/queries/classic_single_bench_press_lifted_weight_query.rb
+++ b/app/queries/classic_single_bench_press_lifted_weight_query.rb
@@ -1,0 +1,13 @@
+class ClassicSingleBenchPressLiftedWeightQuery < Query
+	def initialize(user)
+    @user = user
+  end
+
+  def call
+    QueryBuilder.new(@user)
+      .with_competition_type(0)
+      .with_gearcategory_type(0)
+      .with_category("シングルベンチプレス")
+      .pluck_values("competition_results.total_lifted_weight")
+  end
+end

--- a/app/queries/classic_single_bench_press_lifted_weight_query.rb
+++ b/app/queries/classic_single_bench_press_lifted_weight_query.rb
@@ -1,5 +1,5 @@
 class ClassicSingleBenchPressLiftedWeightQuery < Query
-	def initialize(user)
+  def initialize(user)
     @user = user
   end
 

--- a/app/queries/equipped_powerlifting_ipfglpoints_query.rb
+++ b/app/queries/equipped_powerlifting_ipfglpoints_query.rb
@@ -1,5 +1,5 @@
 class EquippedPowerliftingIpfglpointsQuery < Query
-	def initialize(user)
+  def initialize(user)
     @user = user
   end
 

--- a/app/queries/equipped_powerlifting_ipfglpoints_query.rb
+++ b/app/queries/equipped_powerlifting_ipfglpoints_query.rb
@@ -1,0 +1,14 @@
+class EquippedPowerliftingIpfglpointsQuery < Query
+
+	def initialize(user)
+    @user = user
+  end
+
+  def call
+    QueryBuilder.new(@user)
+      .with_competition_type(0)
+      .with_gearcategory_type(1)
+      .with_category("パワーリフティング")
+      .pluck_values("competition_results.ipf_points")
+  end
+end

--- a/app/queries/equipped_powerlifting_ipfglpoints_query.rb
+++ b/app/queries/equipped_powerlifting_ipfglpoints_query.rb
@@ -1,5 +1,4 @@
 class EquippedPowerliftingIpfglpointsQuery < Query
-
 	def initialize(user)
     @user = user
   end

--- a/app/queries/equipped_powerlifting_total_lifted_weight_query.rb
+++ b/app/queries/equipped_powerlifting_total_lifted_weight_query.rb
@@ -1,0 +1,14 @@
+class EquippedPowerliftingTotalLiftedWeightQuery < Query
+
+	def initialize(user)
+    @user = user
+  end
+
+  def call
+    QueryBuilder.new(@user)
+      .with_competition_type(0)
+      .with_gearcategory_type(1)
+      .with_category("パワーリフティング")
+      .pluck_values("competition_results.total_lifted_weight")
+  end
+end

--- a/app/queries/equipped_powerlifting_total_lifted_weight_query.rb
+++ b/app/queries/equipped_powerlifting_total_lifted_weight_query.rb
@@ -1,6 +1,5 @@
 class EquippedPowerliftingTotalLiftedWeightQuery < Query
-
-	def initialize(user)
+  def initialize(user)
     @user = user
   end
 

--- a/app/queries/equipped_single_bench_press_ipfglpoints_query.rb
+++ b/app/queries/equipped_single_bench_press_ipfglpoints_query.rb
@@ -1,5 +1,4 @@
 class EquippedSingleBenchPressIpfglpointsQuery < Query
-
 	def initialize(user)
     @user = user
   end

--- a/app/queries/equipped_single_bench_press_ipfglpoints_query.rb
+++ b/app/queries/equipped_single_bench_press_ipfglpoints_query.rb
@@ -1,0 +1,14 @@
+class EquippedSingleBenchPressIpfglpointsQuery < Query
+
+	def initialize(user)
+    @user = user
+  end
+
+  def call
+    QueryBuilder.new(@user)
+      .with_competition_type(0)
+      .with_gearcategory_type(1)
+      .with_category("シングルベンチプレス")
+      .pluck_values("competition_results.ipf_points")
+  end
+end

--- a/app/queries/equipped_single_bench_press_ipfglpoints_query.rb
+++ b/app/queries/equipped_single_bench_press_ipfglpoints_query.rb
@@ -1,5 +1,5 @@
 class EquippedSingleBenchPressIpfglpointsQuery < Query
-	def initialize(user)
+  def initialize(user)
     @user = user
   end
 

--- a/app/queries/equipped_single_bench_press_lifted_weight_query.rb
+++ b/app/queries/equipped_single_bench_press_lifted_weight_query.rb
@@ -1,0 +1,13 @@
+class EquippedSingleBenchPressLiftedWeightQuery < Query
+	def initialize(user)
+    @user = user
+  end
+
+  def call
+    QueryBuilder.new(@user)
+      .with_competition_type(0)
+      .with_gearcategory_type(1)
+      .with_category("シングルベンチプレス")
+      .pluck_values("competition_results.total_lifted_weight")
+  end
+end

--- a/app/queries/equipped_single_bench_press_lifted_weight_query.rb
+++ b/app/queries/equipped_single_bench_press_lifted_weight_query.rb
@@ -1,5 +1,5 @@
 class EquippedSingleBenchPressLiftedWeightQuery < Query
-	def initialize(user)
+  def initialize(user)
     @user = user
   end
 

--- a/app/queries/query.rb
+++ b/app/queries/query.rb
@@ -1,0 +1,13 @@
+class Query
+  class << self
+    delegate :call, to: :new
+  end
+
+  def call
+    raise NotImplementedError
+  end
+
+  private
+
+  attr_reader :relation
+end

--- a/app/queries/query.rb
+++ b/app/queries/query.rb
@@ -1,6 +1,6 @@
 class Query
-  class << self
-    delegate :call, to: :new
+  def self.call(*args)
+    new(*args).call
   end
 
   def call

--- a/app/queries/query_builder.rb
+++ b/app/queries/query_builder.rb
@@ -1,0 +1,29 @@
+class QueryBuilder
+  def initialize(user)
+    @user = user
+    @relation = user.competitions.joins(:competition_record => :competition_result).where(participation_status: 0).order(date: :asc)
+  end
+
+	def with_competition_type(competition_type)
+		@relation = @relation.where(competition_type: competition_type)
+    self
+	end
+
+  def with_gearcategory_type(gearcategory_type)
+    @relation = @relation.where(gearcategory_type: gearcategory_type)
+    self
+  end
+
+  def with_category(category)
+    @relation = @relation.where(category: category)
+    self
+  end
+
+  def pluck_values(column)
+    @relation.pluck("competitions.date", column)
+  end
+
+  private
+
+  attr_reader :relation
+end

--- a/app/queries/query_builder.rb
+++ b/app/queries/query_builder.rb
@@ -4,10 +4,10 @@ class QueryBuilder
     @relation = user.competitions.joins(:competition_record => :competition_result).where(participation_status: 0).order(date: :asc)
   end
 
-	def with_competition_type(competition_type)
-		@relation = @relation.where(competition_type: competition_type)
+  def with_competition_type(competition_type)
+    @relation = @relation.where(competition_type: competition_type)
     self
-	end
+  end
 
   def with_gearcategory_type(gearcategory_type)
     @relation = @relation.where(gearcategory_type: gearcategory_type)

--- a/app/views/charts/index.html.erb
+++ b/app/views/charts/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Charts#index</h1>
+<p>Find me in app/views/charts/index.html.erb</p>

--- a/app/views/charts/index.html.erb
+++ b/app/views/charts/index.html.erb
@@ -1,2 +1,41 @@
-<h1>Charts#index</h1>
-<p>Find me in app/views/charts/index.html.erb</p>
+<% content_for :head do %>
+    <title>大会結果一覧 | PowerLifter's Log</title>
+<% end %>
+<div class="mx-auto w-full max-w-screen-sm text-center pb-16">
+  <div class="mx-auto max-w-80 min-w-80 rounded-lg bg-white shadow my-4 p-2">
+    <h1>パワーリフティング(ノーギア)<br/>合計重量</h1>
+      <%= line_chart [["2020-5-3", 287.5], ["2020-10-1", 247.5], ["2021-10-1", 280.0]],
+      xtitle: "開催日" ,
+      ytitle: "重量(kg)",
+      decimal: ",",
+      empty: "データがありません"
+      %>
+  </div>
+  <div class="mx-auto max-w-80 min-w-80 rounded-lg bg-white shadow my-4 p-2">
+    <h1>パワーリフティング(フルギア)<br/>合計重量</h1>
+      <%= line_chart [["2020-1-1", 300.0], ["2022-2-1", 322.5], ["2023-2-2", 405.0], ["2024-3-2", 500.0], ["2025-4-2", 522.5], ["2026-5-2", 600.5], ["2027-6-2", 725.5]],
+      xtitle: "開催日" ,
+      ytitle: "重量(kg)",
+      decimal: ",",
+      empty: "データがありません"
+      %>
+  </div>
+  <div class="mx-auto max-w-80 min-w-80 rounded-lg bg-white shadow my-4 p-2">
+    <h1>シングルベンチプレス(ノーギア)<br/>重量</h1>
+      <%= line_chart [["2020-1-1", 300.0], ["2022-2-1", 322.5], ["2023-2-2", 405.0], ["2024-3-2", 500.0], ["2025-4-2", 522.5], ["2026-5-2", 600.5], ["2027-6-2", 725.5]],
+      xtitle: "開催日" ,
+      ytitle: "重量(kg)",
+      decimal: ",",
+      empty: "データがありません"
+      %>
+  </div>
+  <div class="mx-auto max-w-80 min-w-80 rounded-lg bg-white shadow my-4 p-2">
+    <h1>シングルベンチプレス(フルギア)<br/>重量</h1>
+      <%= line_chart [["2020-1-1", 300.0], ["2022-2-1", 322.5], ["2023-2-2", 405.0], ["2024-3-2", 500.0], ["2025-4-2", 522.5], ["2026-5-2", 600.5], ["2027-6-2", 725.5]],
+      xtitle: "開催日" ,
+      ytitle: "重量(kg)",
+      decimal: ",",
+      empty: "データがありません"
+      %>
+  </div>
+</div>

--- a/app/views/shared/_bottom_navbar.html.erb
+++ b/app/views/shared/_bottom_navbar.html.erb
@@ -11,7 +11,7 @@
     </svg>
     <span class="btm-nav-label"><%= t('bottom_navi.create') %></span>
   <% end %>
-  <%= link_to '#' do %>
+  <%= link_to charts_path do %>
     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="#fafafa" viewBox="0 0 24 24" stroke="#fc345c"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>
     <span class="btm-nav-label"><%= t('bottom_navi.statics') %></span>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   resource :profile, only: [:new, :create, :show, :edit, :update]
   get 'profile/existence', to: "profiles#existence"
   resources :password_resets, only: [:create, :edit, :update, :new]
-
+  resources :charts, only: [:index]
   resources :competitions do
     resource :competition_record, only: [:destroy]
     scope module: 'record' do

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.4",
     "autoprefixer": "^10.4.19",
+    "chart.js": "^4.4.3",
+    "chartkick": "^5.0.1",
     "daisyui": "^4.9.0",
     "esbuild": "^0.20.2",
     "postcss": "^8.4.38",

--- a/test/controllers/charts_controller_test.rb
+++ b/test/controllers/charts_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class ChartsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get charts_index_url
+    assert_response :success
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,6 +184,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@kurkle/color@^0.3.0":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.2.tgz#5acd38242e8bde4f9986e7913c8fdf49d3aa199f"
+  integrity sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -311,6 +316,27 @@ caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001599:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001603.tgz#605046a5bdc95ba4a92496d67e062522dce43381"
   integrity sha512-iL2iSS0eDILMb9n5yKQoTBim9jMZ0Yrk8g0N9K7UzYyWnfIKzXBZD5ngpM37ZcL/cv0Mli8XtVMRYMQAfFpi5Q==
 
+chart.js@4, chart.js@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.4.3.tgz#3b2e11e7010fefa99b07d0349236f5098e5226ad"
+  integrity sha512-qK1gkGSRYcJzqrrzdR6a+I0vQ4/R+SoODXyAjscQ/4mzuNzySaMCd+hyVxitSY1+L2fjPD1Gbn+ibNqRmwQeLw==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
+
+chartjs-adapter-date-fns@>=3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-3.0.0.tgz#c25f63c7f317c1f96f9a7c44bd45eeedb8a478e5"
+  integrity sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==
+
+chartkick@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/chartkick/-/chartkick-5.0.1.tgz#f557ff8560f974343dc65c7fc34ce1e8326d8ee7"
+  integrity sha512-4F3tWI3eBQgnjCYZIZ+fHOaJuNyxeyhDE2Tm+voOWB19hDjSJceys/spzN52DOn8bWepNESGXvPVTGU1jeFsbA==
+  optionalDependencies:
+    chart.js "4"
+    chartjs-adapter-date-fns ">=3"
+    date-fns ">=2"
+
 chokidar@^3.5.3:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
@@ -379,6 +405,11 @@ daisyui@^4.9.0:
     culori "^3"
     picocolors "^1"
     postcss-js "^4"
+
+date-fns@>=2:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
+  integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
 
 didyoumean@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
## 変更の概要

* 変更の概要
成績グラフ機能を実装しました

* 関連するIssueやプルリクエスト
close #13 
#237 

## やったこと
### ビュー
以下の4つの成績をグラフ化しました
- パワーリフティング 合計重量(ノーギア)
- シングルベンチプレス 合計重量(ノーギア)
- パワーリフティング 合計重量(フルギア)
- シングルベンチプレス 合計重量(フルギア) 

横軸は日付、縦軸は重量kg
日付はフォーマットメソッドをヘルパーに定義した
```Ruby
module ChartsHelper
  def format_dates_and_weights(data)
    data.map do |date, weight|
      # Sun, 03 May 2020のままでは見づらいため、2024-1-1にする
      [date.strftime("%Y-%-m-%-d"), weight]
    end
  end
end
```

### 使用gemとライブラリ
- グラフ描写用ライブラリを `chart.js`
- `gem chartkick`
-  使用したグラフは`line_chart`

### デザインパターン(Query Objects)を使用
- ベースのQueryクラスを作成
 `self.call(*args)`を定義することで、コントローラからクエリオブジェクトを一貫した方法で呼び出す
(*args)には `current_user `の返すデータが引数として渡される
- `QueryBuilder`クラスには各クエリオブジェクトで共通して使用するクエリメソッドを定義
- Queryクラスを継承した各Query Objectのクラスを作成
  - パワーリフティング 合計重量(ノーギア): ClassicPowerliftingIpfglpointsQuery
  - シングルベンチプレス 合計重量(ノーギア): ClassicSingleBenchPressLiftedWeightQuery
  - パワーリフティング 合計重量(フルギア): EquippedPowerliftingTotalLiftedWeightQuery
  - シングルベンチプレス 合計重量(フルギア): EquippedSingleBenchPressLiftedWeightQuery
各クラスには `call` メソッドを定義。
`call` メソッド内で`QueryBuilder`クラスに定義したクエリメソッドをメソッドチェーンで繋げる


## 備考
今後拡張していきたいグラフ機能
- 各競技のipf pointsの成績推移グラフ #272
- 各種目(SQ,BP,DL)の成績推移グラフ #273