### PR TITLE
add: 数字入力フォームのinputmode属性を”decimal”にする

### DIFF
--- a/app/views/record/bench_presses/edit.html.erb
+++ b/app/views/record/bench_presses/edit.html.erb
@@ -14,7 +14,7 @@
 						<div class="flex justify-between">
 							<%= f.label :benchpress_first_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -48,7 +48,7 @@
 						<div class="flex justify-between">
 							<%= f.label :benchpress_second_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -82,7 +82,7 @@
 						<div class="flex justify-between">
 							<%= f.label :benchpress_third_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>

--- a/app/views/record/bench_presses/new.html.erb
+++ b/app/views/record/bench_presses/new.html.erb
@@ -27,7 +27,7 @@
 						<div class="flex justify-between">
 							<%= f.label :benchpress_first_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -61,7 +61,7 @@
 						<div class="flex justify-between">
 							<%= f.label :benchpress_second_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -95,7 +95,7 @@
 						<div class="flex justify-between">
 							<%= f.label :benchpress_third_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>

--- a/app/views/record/deadlifts/edit.html.erb
+++ b/app/views/record/deadlifts/edit.html.erb
@@ -14,7 +14,7 @@
 						<div class="flex justify-between">
 							<%= f.label :deadlift_first_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -48,7 +48,7 @@
 						<div class="flex justify-between">
 							<%= f.label :deadlift_second_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -82,7 +82,7 @@
 						<div class="flex justify-between">
 							<%= f.label :deadlift_third_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>

--- a/app/views/record/deadlifts/new.html.erb
+++ b/app/views/record/deadlifts/new.html.erb
@@ -23,7 +23,7 @@
 						<div class="flex justify-between">
 							<%= f.label :deadlift_first_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -57,7 +57,7 @@
 						<div class="flex justify-between">
 							<%= f.label :deadlift_second_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -91,7 +91,7 @@
 						<div class="flex justify-between">
 							<%= f.label :deadlift_third_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>

--- a/app/views/record/squats/edit.html.erb
+++ b/app/views/record/squats/edit.html.erb
@@ -14,7 +14,7 @@
 						<div class="flex justify-between">
 							<%= f.label :squat_first_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -48,7 +48,7 @@
 						<div class="flex justify-between">
 							<%= f.label :squat_second_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -82,7 +82,7 @@
 						<div class="flex justify-between">
 							<%= f.label :squat_third_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>

--- a/app/views/record/squats/new.html.erb
+++ b/app/views/record/squats/new.html.erb
@@ -23,7 +23,7 @@
 						<div class="flex justify-between">
 							<%= f.label :squat_first_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -57,7 +57,7 @@
 						<div class="flex justify-between">
 							<%= f.label :squat_second_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>
@@ -91,7 +91,7 @@
 						<div class="flex justify-between">
 							<%= f.label :squat_third_attempt, class: 'text-xl font-semibold' %>
 							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量" %>
+								<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
 								<span>kg</span>
 							</label>
 						</div>

--- a/app/views/record/weigh_ins/edit.html.erb
+++ b/app/views/record/weigh_ins/edit.html.erb
@@ -13,7 +13,7 @@
 							<p class="text-red-500">(必須)</p>
 						</div>
 						<label class="form-control flex flex-row">
-							<%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder:"検量体重"%>
+							<%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder:"検量体重", inputmode: "decimal"%>
 							<span>kg</span>
 						</label>
 					</div>

--- a/app/views/record/weigh_ins/new.html.erb
+++ b/app/views/record/weigh_ins/new.html.erb
@@ -26,7 +26,7 @@
 							<p class="text-red-500">(必須)</p>
 						</div>
 						<label class="form-control flex flex-row">
-							<%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder:"検量体重"%>
+							<%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder:"検量体重", inputmode: "decimal"%>
 							<span>kg</span>
 						</label>
 					</div>


### PR DESCRIPTION
## 変更の概要

* 変更の概要
数字入力フォームになったとき、自動でスマートフォンの入力モードを
小数点入力モードにする

* 関連するIssueやプルリクエスト
close #164
## なぜこの変更をするのか
スマホ入力のしやすさ向上

## やったこと

text_fieldのinputmode属性を”decimal”にする
試技結果新規登録
- [x] 検量体重
- [x] スクワット各試技入力
- [x] ベンチプレス各試技入力
- [x] デッドリフト各試技入力

試技結果　編集
- [x] 検量体重
- [x] スクワット各試技入力
- [x] ベンチプレス各試技入力
- [x] デッドリフト各試技入力
