### PR TITLE
fix: ページ全体の横スクロール防止 

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-theme="mytheme">
+<html data-theme="mytheme" class="overflow-x-hidden">
   <head>
     <%= yield :head %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -10,7 +10,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="bg-zinc-50 text-gray-700">
+  <body class="bg-zinc-50 text-gray-700 overflow-x-hidden">
     <!-- ヘッダー -->
     <% if logged_in? %>
       <% if @show_header_nav %>


### PR DESCRIPTION
## 変更の概要

* 変更の概要
スマホでみると、横スクロールが出来てしまい画面が左右にブレる
それを防止させるユーティリティクラスを設定

* 関連するIssueやプルリクエスト
close #225 
## なぜこの変更をするのか

概要に理由記載

## やったこと

* [x] htmlタグとbodyタグに `class="overflow-x-hidden"`を設定
