### PR TITLE
fix: 大会結果一覧ページのレイアウト修正

### DIFF
--- a/app/views/competitions/_benchpress_result.html.erb
+++ b/app/views/competitions/_benchpress_result.html.erb
@@ -4,13 +4,13 @@
 </div>
 <div class="text-center">
   <div class="text-sm text-gray-500">1st</div>
-  <div class="text-base font-bold <%= 'line-through' if competition.benchpress_first_attempt_failure?(competition) %>"><%= competition.first_benchpress_result(competition) %>kg</div>
+  <div class="text-base font-bold <%= "line-through" if competition.benchpress_first_attempt_failure?(competition) %>"><%= competition.first_benchpress_result(competition) %>kg</div>
 </div>
 <div class="text-center">
   <div class="text-sm text-gray-500">2st</div>
-  <div class="text-base font-bold <%= 'line-through' if competition.benchpress_second_attempt_failure?(competition) %>"><%= competition.second_benchpress_result(competition) %>kg</div>
+  <div class="text-base font-bold <%= "line-through" if competition.benchpress_second_attempt_failure?(competition) %>"><%= competition.second_benchpress_result(competition) %>kg</div>
 </div>
 <div class="text-center">
   <div class="text-sm text-gray-500">3rd</div>
-  <div class="text-base font-bold <%= 'line-through' if competition.benchpress_third_attempt_failure?(competition) %>"><%= competition.third_benchpress_result(competition) %>kg </div>
+  <div class="text-base font-bold <%= "line-through" if competition.benchpress_third_attempt_failure?(competition) %>"><%= competition.third_benchpress_result(competition) %>kg </div>
 </div>

--- a/app/views/competitions/_benchpress_result.html.erb
+++ b/app/views/competitions/_benchpress_result.html.erb
@@ -1,6 +1,6 @@
 <div class = "mr-1">
-  <div class="text-sm text-red-500">MAX</div>
-  <div class="text-xl font-bold text-red-500"><%= competition.total_lifted_weight_result(competition) %>kg</div>
+  <div class="text-sm text-primary">MAX</div>
+  <div class="text-xl font-bold text-primary"><%= competition.total_lifted_weight_result(competition) %>kg</div>
 </div>
 <div class="text-center">
   <div class="text-sm text-gray-500">1st</div>

--- a/app/views/competitions/_competition.html.erb
+++ b/app/views/competitions/_competition.html.erb
@@ -1,8 +1,8 @@
   <div class="mx-auto max-w-80 min-w-80 rounded-lg bg-white shadow my-4">
     <div class="p-4 border-b border-gray-200">
       <div class="flex items-center justify-left">
-        <span class="text-sm font-medium text-red-500 mr-2"><%= competition.competition_type_i18n %></span>
-        <span class="text-sm font-medium text-red-500 mr-auto"><%= competition.category %></span>
+        <span class="text-sm font-medium text-primary mr-2"><%= competition.competition_type_i18n %></span>
+        <span class="text-sm font-medium text-primary mr-auto"><%= competition.category %></span>
         <%= link_to "詳細", competition_path(competition), class: "btn btn-sm btn-outline btn-accent" %>
       </div>
       <div class="flex flex-col place-items-start">

--- a/app/views/competitions/_competition.html.erb
+++ b/app/views/competitions/_competition.html.erb
@@ -1,9 +1,9 @@
-  <div class="mx-auto max-w-80 min-w-80 rounded-lg bg-white shadow my-4 border-2 border-red-500/50">
+  <div class="mx-auto max-w-80 min-w-80 rounded-lg bg-white shadow my-4">
     <div class="p-4 border-b border-gray-200">
       <div class="flex items-center justify-left">
         <span class="text-sm font-medium text-red-500 mr-2"><%= competition.competition_type_i18n %></span>
         <span class="text-sm font-medium text-red-500 mr-auto"><%= competition.category %></span>
-        <%= link_to "詳細", competition_path(competition), class: "btn btn-sm btn-outline btn-primary" %>
+        <%= link_to "詳細", competition_path(competition), class: "btn btn-sm btn-outline btn-accent" %>
       </div>
       <div class="flex flex-col place-items-start">
         <div class="mt-1 text-sm text-gray-500"><%= competition.date %></div>

--- a/app/views/competitions/_powerlifting_result.html.erb
+++ b/app/views/competitions/_powerlifting_result.html.erb
@@ -1,6 +1,6 @@
 <div class = "mr-1">
-  <div class="text-sm text-red-500">TOTAL</div>
-  <div class="text-xl font-bold text-red-500"><%= competition.total_lifted_weight_result(competition) %>kg</div>
+  <div class="text-sm text-primary">TOTAL</div>
+  <div class="text-xl font-bold text-primary"><%= competition.total_lifted_weight_result(competition) %>kg</div>
 </div>
 <div class="text-center">
   <div class="text-sm text-gray-500">SQ</div>


### PR DESCRIPTION
## 変更の概要

* 変更の概要
大会結果一覧ページのレイアウト修正をした

* 関連するIssueやプルリクエスト
close #222

## なぜこの変更をするのか
* 変更をする理由
色を使いすぎて、見にくいと感じたので

## やったこと
- [x] ボーダーラインを消す
- [x] 詳細ボタンをアクセントカラーに変更する
- [x] 文字色を、プライマリーカラーに合わせる
- [x] シングルベンチプレスの失敗試技の取り消し線が機能していないので対処。
（失敗試技は取り消し線を表示させる）

## 変更内容

#### 変更前
![Image](https://github.com/okaka-c/goodlifterlog/assets/142456748/530c332a-2eb6-4112-b1d3-b603883de2ea)

#### 変更後
![image](https://github.com/user-attachments/assets/ee5c9904-8648-4607-ac09-6690af969e63)
