### PR TITLE
add: Userテーブルにroleカラムを追加し、db:seedでゲストユーザーを登録する

### DIFF
--- a/app/controllers/guest_sessions_controller.rb
+++ b/app/controllers/guest_sessions_controller.rb
@@ -1,0 +1,2 @@
+class GuestSessionsController < ApplicationController
+end

--- a/app/helpers/guest_sessions_helper.rb
+++ b/app/helpers/guest_sessions_helper.rb
@@ -1,0 +1,2 @@
+module GuestSessionsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,6 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   validates :name, presence: true, length: { maximum: 255 }
   validates :reset_password_token, uniqueness: true, allow_nil: true
+
+  enum role: { user: 0, guest: 1}
 end

--- a/db/migrate/20240722122236_add_role_to_users.rb
+++ b/db/migrate/20240722122236_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_24_154757) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_22_122236) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -98,6 +98,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_24_154757) do
     t.datetime "reset_password_token_expires_at"
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
+    t.integer "role", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,15 +10,15 @@ default_password = SecureRandom.urlsafe_base64
 
 # Userをつくる
 User.create!(
-	name: "ゲストユーザー",
-	email: "guest@example.com",
-	password: default_password,
-	password_confirmation: default_password,
-	role: "guest")
+  name: "ゲストユーザー",
+  email: "guest@example.com",
+  password: default_password,
+  password_confirmation: default_password,
+  role: "guest")
 
 guest_user_id = User.find_by(role: "guest").id
 # profileもつくる
 Profile.create!(
-	user_id: guest_user_id,
-	gender: "man",
-	birthday: "2024-05-27")
+  user_id: guest_user_id,
+  gender: "man",
+  birthday: "2024-05-27")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,20 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+default_password = SecureRandom.urlsafe_base64
+
+# Userをつくる
+User.create!(
+	name: "ゲストユーザー",
+	email: "guest@example.com",
+	password: default_password,
+	password_confirmation: default_password,
+	role: "guest")
+
+guest_user_id = User.find_by(role: "guest").id
+# profileもつくる
+Profile.create!(
+	user_id: guest_user_id,
+	gender: "man",
+	birthday: "2024-05-27")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@ rm -f /app/tmp/pids/server.pid
 RAILS_ENV=production bundle exec rails assets:precompile
 RAILS_ENV=production bundle exec rails assets:clean
 RAILS_ENV=production bundle exec rails db:migrate
+RAILS_ENV=production bundle exec rails db:seed
 
 
 # コンテナーのプロセスを実行する。（Dockerfile 内の CMD に設定されているもの。）

--- a/test/controllers/guest_sessions_controller_test.rb
+++ b/test/controllers/guest_sessions_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class GuestSessionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 変更の概要

### 変更の概要
- Userテーブルにroleカラムを追加
- ゲストユーザーをデータベースに登録する


### 関連するIssueやプルリクエスト
 #281 
## なぜこの変更をするのか

### 変更をする理由
- 1つのゲストアカウントを、複数のゲストユーザーでシェアさせるためゲストアカウントを１つ作成する
- ゲストユーザーの判別のため、roleカラムを作成
- 一般ユーザーはuser, ゲストユーザーはguestとする
- ゲストログイン機能にて、ゲストユーザーの場合機能を制限するため判別できるようにした



## やったこと

* [x] usersテーブルにroleカラムを追加した
* [x] roleカラムはenumを使用するため数値型、デフォルトで0(userが入るようにした
* [x]  enumでuserを0, guestを1と定義した
* [x] シードファイルで、ゲストユーザーのuserとprofileのレコードを作成する
* [x] デプロイ時にrails db:seedを実行させる