### PR TITLE
fix: お試しログインボタン消し

### DIFF
--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -18,7 +18,6 @@
         <%= link_to auth_at_provider_path(:provider => :line), class:"flex items-center justify-center hover:brightness-75 mt-2" do %>
           <%= image_tag asset_path("btn_login_base.png") %>
         <% end %>
-        <%= link_to "ゲストログイン(お試し)", guest_login_path, data: { turbo_method: :post } %>
       </article>
     </div>
   </div>


### PR DESCRIPTION
機能制限してから復活させるため

feature #291
