### PR TITLE
add: ゲストアカウントの機能制限と、ゲストログイン時に、ページ上部にゲストログイン中であることを表示

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,15 +3,22 @@ class ApplicationController < ActionController::Base
   before_action :set_header_navi
   before_action :set_bottom_navi
   add_flash_types :success, :danger
+  before_action :restrict_guest_user_actions
 
   private
+
+  def restrict_guest_user_actions
+    if current_user&.guest? && action_name.in?(%w[new create edit update destroy])
+      redirect_to competitions_path, danger: "ゲストユーザーは新規登録・編集・削除機能を実行できません。"
+    end
+  end
 
   def not_authenticated
     redirect_to login_path
   end
 
   def set_bottom_navi
-	  @show_bottom_nav = true
+    @show_bottom_nav = true
   end
 
   def hide_bottom_navi

--- a/app/controllers/guest_sessions_controller.rb
+++ b/app/controllers/guest_sessions_controller.rb
@@ -1,8 +1,10 @@
 class GuestSessionsController < ApplicationController
   skip_before_action :require_login
+  skip_before_action :restrict_guest_user_actions
+
   def create
     guest_user = User.find_by(role: 'guest')
     auto_login(guest_user)
-    redirect_to competitions_path, notice: 'ゲストユーザーとしてログインしました'
+    redirect_to competitions_path, success: 'ゲストユーザーとしてログインしました'
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,5 +1,6 @@
 class UserSessionsController < ApplicationController
-  # ログアウトのみ
+  skip_before_action :restrict_guest_user_actions
+
   def destroy
     logout
     redirect_to root_path, status: :see_other, success: t('.success')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,4 +15,8 @@ class User < ApplicationRecord
   validates :reset_password_token, uniqueness: true, allow_nil: true
 
   enum role: { user: 0, guest: 1}
+
+  def guest?
+    role == 'guest'
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,9 @@
     <% if logged_in? %>
       <% if @show_header_nav %>
         <%= render "shared/header" %>
+        <% if current_user&.guest? %>
+          <%= render "shared/login_prompt" %>
+        <% end %>
       <% end %>
     <% else %>
       <%= render "shared/before_login_header" %>

--- a/app/views/shared/_login_prompt.html.erb
+++ b/app/views/shared/_login_prompt.html.erb
@@ -1,0 +1,18 @@
+<div role="alert" class="alert shadow bg-white mt-1 mb-4">
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    class="stroke-info h-6 w-6 shrink-0">
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+  </svg>
+  <div>
+    <h3 class="font-bold text-info">ゲストユーザーとしてログインしています。</h3>
+    <div class="text-xs">フル機能を利用するには、ログアウトして会員登録してください</div>
+  </div>
+  <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete }, class: "btn btn-sm btn-info text-white" %>
+</div>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -18,6 +18,7 @@
         <%= link_to auth_at_provider_path(:provider => :line), class:"flex items-center justify-center hover:brightness-75 mt-2" do %>
           <%= image_tag asset_path("btn_login_base.png") %>
         <% end %>
+        <%= link_to "ゲストログイン(お試し)", guest_login_path, data: { turbo_method: :post } %>
       </article>
     </div>
   </div>


### PR DESCRIPTION
## 変更の概要

* 変更の概要
ゲストアカウントの機能制限
ゲストアカウントログイン時に、ページ上部にゲストログイン中であることを表示
* 関連するIssueやプルリクエスト
close #281 

## なぜこの変更をするのか
- ゲストアカウントには編集・新規登録・削除をさせないようにした
  - テストデータを変えられたくない

- ページ上部にゲストログイン中であることを表示
  - ユーザーが自分が今何の権限でログインしているかわからないため
## やったこと

### ゲストアカウントの機能制限
* [x] application_controller.rbにて、`restrict_guest_user_actions` メソッドを定義
ゲストユーザーがnew, create, edit, update, destroyアクションを実行しようとした場合、大会一覧ページにリダイレクトされ、アラートメッセージが表示されます。
GuestSessionsControllerのcreateアクションではskip
UserSessionsのdestroyのdestroyアクションではskip
```
def restrict_guest_user_actions
    if current_user&.guest? && action_name.in?(%w[new create edit update destroy])
      redirect_to competitions_path, danger: "ゲストユーザーは新規登録・編集・削除機能を実行できません。"
    end
  end
```
* [x] ゲストアカウントログイン時にページ上部にゲストログイン中であることを表示
![image](https://github.com/user-attachments/assets/c2de9fe7-1e03-440c-98fa-e08cc5b4289d)
トップページに遷移させる
