### PR TITLE
fix: 大会一覧のシングルベンチに記載してある「2st」を「2nd」に修正

### DIFF
--- a/app/views/competitions/_benchpress_result.html.erb
+++ b/app/views/competitions/_benchpress_result.html.erb
@@ -7,7 +7,7 @@
   <div class="text-base font-bold <%= "line-through" if competition.benchpress_first_attempt_failure?(competition) %>"><%= competition.first_benchpress_result(competition) %>kg</div>
 </div>
 <div class="text-center">
-  <div class="text-sm text-gray-500">2st</div>
+  <div class="text-sm text-gray-500">2nd</div>
   <div class="text-base font-bold <%= "line-through" if competition.benchpress_second_attempt_failure?(competition) %>"><%= competition.second_benchpress_result(competition) %>kg</div>
 </div>
 <div class="text-center">


### PR DESCRIPTION
## 変更の概要

* 変更の概要
出場済大会一覧にて、シングルベンチの第二試技の表記が「2st」になっていた
「2nd」が正のため修正した

* 関連するIssueやプルリクエスト
close #288
