### PR TITLE
update: ラジオボタンのラベルをクリックしたときに、そのラジオボタンが選択されるようにした

### DIFF
--- a/app/views/competitions/_form.html.erb
+++ b/app/views/competitions/_form.html.erb
@@ -35,12 +35,12 @@
     <div class="form-control mb-3">
       <div class="flex flex-col mt-2">
         <label class="flex items-center mb-3">
-          <%= f.radio_button :competition_type, 'official', class: 'radio radio-primary' %>
-          <span class="ml-2"><%= f.label :competition_type, Competition.competition_types_i18n["official"] %></span>
+          <%= f.radio_button :competition_type, 'official', class: 'radio radio-primary', id: 'official' %>
+          <span class="ml-2"><%= f.label :competition_type, Competition.competition_types_i18n["official"], for: 'official' %></span>
         </label>
         <label class="flex items-center">
-          <%= f.radio_button :competition_type, 'unofficial', class: 'radio radio-primary' %>
-          <span class="ml-2"><%= f.label :competition_type, Competition.competition_types_i18n["unofficial"] %></span>
+          <%= f.radio_button :competition_type, 'unofficial', class: 'radio radio-primary', id: 'unofficial' %>
+          <span class="ml-2"><%= f.label :competition_type, Competition.competition_types_i18n["unofficial"], for: 'unofficial' %></span>
         </label>
       </div>
       <%= render 'shared/error_messages', object: f.object, attribute: :competition_type %>
@@ -55,12 +55,12 @@
     <div class="form-control mb-3">
       <div class="flex flex-col mt-2">
         <label class="flex items-center mb-3">
-          <%= f.radio_button :gearcategory_type, 'raw', class: 'radio radio-primary' %>
-          <span class="ml-2"><%= f.label :gearcategory_type, Competition.gearcategory_types_i18n["raw"] %></span>
+          <%= f.radio_button :gearcategory_type, 'raw', class: 'radio radio-primary', id: 'raw' %>
+          <span class="ml-2"><%= f.label :gearcategory_type, Competition.gearcategory_types_i18n["raw"], for: 'raw' %></span>
         </label>
         <label class="flex items-center">
-          <%= f.radio_button :gearcategory_type, 'equipped', class: 'radio radio-primary' %>
-          <span class="ml-2"><%= f.label :gearcategory_type, Competition.gearcategory_types_i18n["equipped"] %></span>
+          <%= f.radio_button :gearcategory_type, 'equipped', class: 'radio radio-primary', id: 'equipped' %>
+          <span class="ml-2"><%= f.label :gearcategory_type, Competition.gearcategory_types_i18n["equipped"], for: 'equipped' %></span>
         </label>
       </div>
       <%= render 'shared/error_messages', object: f.object, attribute: :gearcategory_type %>
@@ -75,12 +75,12 @@
     <div class="form-control mb-3">
       <div class="flex flex-col mt-2">
         <label class="flex items-center mb-3">
-          <%= f.radio_button :category, "パワーリフティング", class: 'radio radio-primary', disabled: @competition_record.present? %>
-          <span class="ml-2"><%= f.label :category, "パワーリフティング" %></span>
+          <%= f.radio_button :category, "パワーリフティング", class: 'radio radio-primary', disabled: @competition_record.present?, id: 'powerlifting' %>
+          <span class="ml-2"><%= f.label :category, "パワーリフティング", for: 'powerlifting' %></span>
         </label>
         <label class="flex items-center">
-          <%= f.radio_button :category, "シングルベンチプレス", class: 'radio radio-primary', disabled: @competition_record.present? %>
-          <span class="ml-2"><%= f.label :category, "シングルベンチプレス" %></span>
+          <%= f.radio_button :category, "シングルベンチプレス", class: 'radio radio-primary', disabled: @competition_record.present?, id: 'single_benchpress' %>
+          <span class="ml-2"><%= f.label :category, "シングルベンチプレス", for: 'single_benchpress' %></span>
         </label>
       </div>
       <%= render 'shared/error_messages', object: f.object, attribute: :category %>

--- a/app/views/record/bench_presses/edit.html.erb
+++ b/app/views/record/bench_presses/edit.html.erb
@@ -1,121 +1,121 @@
 <% content_for :head do %>
-    <title><%= @competition.name %> | PowerLifter's Log</title>
+  <title><%= @competition.name %> | PowerLifter's Log</title>
 <% end %>
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
       <h1 class="text-2xl text-center mb-5 font-bold">ベンチプレス結果 編集</h1>
-			<%= form_with model: @bench_press, url: competition_bench_presse_path(@competition), method: "patch" do |f| %>
-				<!-- ベンチプレス試技結果 -->
-				<!-- ベンチプレス第１試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :benchpress_first_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_first_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "未試行" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_first_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "成功" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_first_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "失敗" %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_first_attempt_result %>
-					</div>
-				</div>
-				<!-- ベンチプレス第2試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :benchpress_second_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_second_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "未試行" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_second_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "成功" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_second_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "失敗" %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_second_attempt_result %>
-					</div>
-				</div>
-				<!-- ベンチプレス第3試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :benchpress_third_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_third_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "未試行" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_third_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "成功" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_third_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "失敗" %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_third_attempt_result %>
-					</div>
-				</div>
-				<!-- ボタン -->
-				<div class="form-control mt-6 flex flex-row justify-center">
-					<div>
-						<%= f.submit "更新", class: 'btn btn-accent btn-sm w-24' %>
-					</div>
-				</div>
-			<% end %>
+      <%= form_with model: @bench_press, url: competition_bench_presse_path(@competition), method: "patch" do |f| %>
+        <!-- ベンチプレス試技結果 -->
+        <!-- ベンチプレス第１試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :benchpress_first_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_first_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :benchpress_first_attempt_result, "未試行" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_first_attempt_result, 'success', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :benchpress_first_attempt_result, "成功" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_first_attempt_result, 'failure', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :benchpress_first_attempt_result, "失敗" %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_first_attempt_result %>
+          </div>
+        </div>
+        <!-- ベンチプレス第2試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :benchpress_second_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_second_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :benchpress_second_attempt_result, "未試行" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_second_attempt_result, 'success', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :benchpress_second_attempt_result, "成功" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_second_attempt_result, 'failure', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :benchpress_second_attempt_result, "失敗" %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_second_attempt_result %>
+          </div>
+        </div>
+        <!-- ベンチプレス第3試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :benchpress_third_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_third_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :benchpress_third_attempt_result, "未試行" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_third_attempt_result, 'success', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :benchpress_third_attempt_result, "成功" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_third_attempt_result, 'failure', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :benchpress_third_attempt_result, "失敗" %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :benchpress_third_attempt_result %>
+          </div>
+        </div>
+        <!-- ボタン -->
+        <div class="form-control mt-6 flex flex-row justify-center">
+          <div>
+            <%= f.submit "更新", class: 'btn btn-accent btn-sm w-24' %>
+          </div>
+        </div>
+      <% end %>
       <!-- ここまでform_withを使う形に修正 -->
     </div>
   </div>

--- a/app/views/record/bench_presses/edit.html.erb
+++ b/app/views/record/bench_presses/edit.html.erb
@@ -25,16 +25,16 @@
             <label class="form-control">
                 <div class="flex justify-between items-center mt-2">
                     <label class="flex items-center">
-                        <%= f.radio_button :benchpress_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :benchpress_first_attempt_result, "未試行" %></span>
+                        <%= f.radio_button :benchpress_first_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'benchpress_first_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :benchpress_first_attempt_result, "未試行", for: 'benchpress_first_attempt_not_attempted' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :benchpress_first_attempt_result, 'success', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :benchpress_first_attempt_result, "成功" %></span>
+                        <%= f.radio_button :benchpress_first_attempt_result, 'success', class: 'radio radio-primary', id: 'benchpress_first_attempt_success' %>
+                        <span class="ml-2"><%= f.label :benchpress_first_attempt_result, "成功", for: 'benchpress_first_attempt_success' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :benchpress_first_attempt_result, 'failure', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :benchpress_first_attempt_result, "失敗" %></span>
+                        <%= f.radio_button :benchpress_first_attempt_result, 'failure', class: 'radio radio-primary', id: 'benchpress_first_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :benchpress_first_attempt_result, "失敗", for: 'benchpress_first_attempt_failure' %></span>
                     </label>
                 </div>
             </label>
@@ -59,16 +59,16 @@
             <label class="form-control">
                 <div class="flex justify-between items-center mt-2">
                     <label class="flex items-center">
-                        <%= f.radio_button :benchpress_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :benchpress_second_attempt_result, "未試行" %></span>
+                        <%= f.radio_button :benchpress_second_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'benchpress_second_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :benchpress_second_attempt_result, "未試行", for: 'benchpress_second_attempt_not_attempted' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :benchpress_second_attempt_result, 'success', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :benchpress_second_attempt_result, "成功" %></span>
+                        <%= f.radio_button :benchpress_second_attempt_result, 'success', class: 'radio radio-primary', id: 'benchpress_second_attempt_success' %>
+                        <span class="ml-2"><%= f.label :benchpress_second_attempt_result, "成功", for: 'benchpress_second_attempt_success' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :benchpress_second_attempt_result, 'failure', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :benchpress_second_attempt_result, "失敗" %></span>
+                        <%= f.radio_button :benchpress_second_attempt_result, 'failure', class: 'radio radio-primary', id: 'benchpress_second_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :benchpress_second_attempt_result, "失敗", for: 'benchpress_second_attempt_failure' %></span>
                     </label>
                 </div>
             </label>
@@ -93,16 +93,16 @@
             <label class="form-control">
                 <div class="flex justify-between items-center mt-2">
                     <label class="flex items-center">
-                        <%= f.radio_button :benchpress_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :benchpress_third_attempt_result, "未試行" %></span>
+                        <%= f.radio_button :benchpress_third_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'benchpress_third_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :benchpress_third_attempt_result, "未試行", for: 'benchpress_third_attempt_not_attempted' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :benchpress_third_attempt_result, 'success', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :benchpress_third_attempt_result, "成功" %></span>
+                        <%= f.radio_button :benchpress_third_attempt_result, 'success', class: 'radio radio-primary', id: 'benchpress_third_attempt_success' %>
+                        <span class="ml-2"><%= f.label :benchpress_third_attempt_result, "成功", for: 'benchpress_third_attempt_success' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :benchpress_third_attempt_result, 'failure', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :benchpress_third_attempt_result, "失敗" %></span>
+                        <%= f.radio_button :benchpress_third_attempt_result, 'failure', class: 'radio radio-primary', id: 'benchpress_third_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :benchpress_third_attempt_result, "失敗", for: 'benchpress_third_attempt_failure' %></span>
                     </label>
                 </div>
             </label>

--- a/app/views/record/bench_presses/new.html.erb
+++ b/app/views/record/bench_presses/new.html.erb
@@ -38,16 +38,16 @@
 						<label class="form-control">
 								<div class="flex justify-between items-center mt-2">
 										<label class="flex items-center">
-												<%= f.radio_button :benchpress_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "未試行" %></span>
+												<%= f.radio_button :benchpress_first_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'benchpress_first_attempt_not_attempted' %>
+												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "未試行", for: 'benchpress_first_attempt_not_attempted' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :benchpress_first_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "成功" %></span>
+												<%= f.radio_button :benchpress_first_attempt_result, 'success', class: 'radio radio-primary', id: 'benchpress_first_attempt_success' %>
+												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "成功", for: 'benchpress_first_attempt_success' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :benchpress_first_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "失敗" %></span>
+												<%= f.radio_button :benchpress_first_attempt_result, 'failure', class: 'radio radio-primary', id: 'benchpress_first_attempt_failure' %>
+												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "失敗", for: 'benchpress_first_attempt_failure' %></span>
 										</label>
 								</div>
 						</label>
@@ -72,16 +72,16 @@
 						<label class="form-control">
 								<div class="flex justify-between items-center mt-2">
 										<label class="flex items-center">
-												<%= f.radio_button :benchpress_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "未試行" %></span>
+												<%= f.radio_button :benchpress_second_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'benchpress_second_attempt_not_attempted' %>
+												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "未試行", for: 'benchpress_second_attempt_not_attempted' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :benchpress_second_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "成功" %></span>
+												<%= f.radio_button :benchpress_second_attempt_result, 'success', class: 'radio radio-primary', id: 'benchpress_second_attempt_success' %>
+												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "成功", for: 'benchpress_second_attempt_success' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :benchpress_second_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "失敗" %></span>
+												<%= f.radio_button :benchpress_second_attempt_result, 'failure', class: 'radio radio-primary', id: 'benchpress_second_attempt_failure' %>
+												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "失敗", for: 'benchpress_second_attempt_failure' %></span>
 										</label>
 								</div>
 						</label>
@@ -106,16 +106,16 @@
 						<label class="form-control">
 								<div class="flex justify-between items-center mt-2">
 										<label class="flex items-center">
-												<%= f.radio_button :benchpress_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "未試行" %></span>
+												<%= f.radio_button :benchpress_third_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'benchpress_third_attempt_not_attempted' %>
+												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "未試行", for: 'benchpress_third_attempt_not_attempted' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :benchpress_third_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "成功" %></span>
+												<%= f.radio_button :benchpress_third_attempt_result, 'success', class: 'radio radio-primary', id: 'benchpress_third_attempt_success' %>
+												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "成功", for: 'benchpress_third_attempt_success' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :benchpress_third_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "失敗" %></span>
+												<%= f.radio_button :benchpress_third_attempt_result, 'failure', class: 'radio radio-primary', id: 'benchpress_third_attempt_failure' %>
+												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "失敗", for: 'benchpress_third_attempt_failure' %></span>
 										</label>
 								</div>
 						</label>

--- a/app/views/record/bench_presses/new.html.erb
+++ b/app/views/record/bench_presses/new.html.erb
@@ -1,134 +1,134 @@
 <% content_for :head do %>
-    <title><%= @competition.name %> | PowerLifter's Log</title>
+  <title><%= @competition.name %> | PowerLifter's Log</title>
 <% end %>
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
       <div class="mb-5 flex justify-center">
-				<ul class="steps">
-					<li class="step step-primary text-[10px]">検量体重</li>
-					<% unless @competition.category == "シングルベンチプレス" %>
-						<li class="step step-primary text-[10px]">スクワット</li>
-					<% end %>
-					<li class="step step-primary text-[10px] text-orange-600 font-bold">ベンチプレス</li>
-					<% unless @competition.category == "シングルベンチプレス" %>
-						<li class="step text-[10px]">デッドリフト</li>
-					<% end %>
-					<li class="step text-[10px]">振り返り<br>コメント</li>
-				</ul>
-			</div>
+        <ul class="steps">
+          <li class="step step-primary text-[10px]">検量体重</li>
+          <% unless @competition.category == "シングルベンチプレス" %>
+            <li class="step step-primary text-[10px]">スクワット</li>
+          <% end %>
+          <li class="step step-primary text-[10px] text-orange-600 font-bold">ベンチプレス</li>
+          <% unless @competition.category == "シングルベンチプレス" %>
+            <li class="step text-[10px]">デッドリフト</li>
+          <% end %>
+          <li class="step text-[10px]">振り返り<br>コメント</li>
+        </ul>
+      </div>
       <h1 class="text-2xl text-center mb-5 font-bold">ベンチプレス結果 登録</h1>
-			<%= form_with model: @bench_press, url: competition_bench_presse_path(@competition)  do |f| %>
-				<!-- ベンチプレス試技結果 -->
-				<!-- ベンチプレス第１試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :benchpress_first_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_first_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_first_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'benchpress_first_attempt_not_attempted' %>
-												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "未試行", for: 'benchpress_first_attempt_not_attempted' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_first_attempt_result, 'success', class: 'radio radio-primary', id: 'benchpress_first_attempt_success' %>
-												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "成功", for: 'benchpress_first_attempt_success' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_first_attempt_result, 'failure', class: 'radio radio-primary', id: 'benchpress_first_attempt_failure' %>
-												<span class="ml-2"><%= f.label :benchpress_first_attempt_result, "失敗", for: 'benchpress_first_attempt_failure' %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_first_attempt_result %>
-					</div>
-				</div>
-				<!-- ベンチプレス第2試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :benchpress_second_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_second_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_second_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'benchpress_second_attempt_not_attempted' %>
-												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "未試行", for: 'benchpress_second_attempt_not_attempted' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_second_attempt_result, 'success', class: 'radio radio-primary', id: 'benchpress_second_attempt_success' %>
-												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "成功", for: 'benchpress_second_attempt_success' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_second_attempt_result, 'failure', class: 'radio radio-primary', id: 'benchpress_second_attempt_failure' %>
-												<span class="ml-2"><%= f.label :benchpress_second_attempt_result, "失敗", for: 'benchpress_second_attempt_failure' %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_second_attempt_result %>
-					</div>
-				</div>
-				<!-- ベンチプレス第3試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :benchpress_third_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_third_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_third_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'benchpress_third_attempt_not_attempted' %>
-												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "未試行", for: 'benchpress_third_attempt_not_attempted' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_third_attempt_result, 'success', class: 'radio radio-primary', id: 'benchpress_third_attempt_success' %>
-												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "成功", for: 'benchpress_third_attempt_success' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :benchpress_third_attempt_result, 'failure', class: 'radio radio-primary', id: 'benchpress_third_attempt_failure' %>
-												<span class="ml-2"><%= f.label :benchpress_third_attempt_result, "失敗", for: 'benchpress_third_attempt_failure' %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: f.object, attribute: :benchpress_third_attempt_result %>
-					</div>
-				</div>
-				<!-- ボタン -->
-				<div class="form-control mt-6 flex flex-row justify-center">
-					<div>
-						<%= f.submit "次の種目へ", class: 'btn btn-accent btn-sm w-24' %>
-					</div>
-				</div>
-			<% end %>
+      <%= form_with model: @bench_press, url: competition_bench_presse_path(@competition)  do |f| %>
+        <!-- ベンチプレス試技結果 -->
+        <!-- ベンチプレス第１試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :benchpress_first_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :benchpress_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: f.object, attribute: :benchpress_first_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_first_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'benchpress_first_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :benchpress_first_attempt_result, "未試行", for: 'benchpress_first_attempt_not_attempted' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_first_attempt_result, 'success', class: 'radio radio-primary', id: 'benchpress_first_attempt_success' %>
+                        <span class="ml-2"><%= f.label :benchpress_first_attempt_result, "成功", for: 'benchpress_first_attempt_success' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_first_attempt_result, 'failure', class: 'radio radio-primary', id: 'benchpress_first_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :benchpress_first_attempt_result, "失敗", for: 'benchpress_first_attempt_failure' %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: f.object, attribute: :benchpress_first_attempt_result %>
+          </div>
+        </div>
+        <!-- ベンチプレス第2試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :benchpress_second_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :benchpress_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: f.object, attribute: :benchpress_second_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_second_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'benchpress_second_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :benchpress_second_attempt_result, "未試行", for: 'benchpress_second_attempt_not_attempted' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_second_attempt_result, 'success', class: 'radio radio-primary', id: 'benchpress_second_attempt_success' %>
+                        <span class="ml-2"><%= f.label :benchpress_second_attempt_result, "成功", for: 'benchpress_second_attempt_success' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_second_attempt_result, 'failure', class: 'radio radio-primary', id: 'benchpress_second_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :benchpress_second_attempt_result, "失敗", for: 'benchpress_second_attempt_failure' %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: f.object, attribute: :benchpress_second_attempt_result %>
+          </div>
+        </div>
+        <!-- ベンチプレス第3試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :benchpress_third_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :benchpress_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: f.object, attribute: :benchpress_third_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_third_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'benchpress_third_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :benchpress_third_attempt_result, "未試行", for: 'benchpress_third_attempt_not_attempted' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_third_attempt_result, 'success', class: 'radio radio-primary', id: 'benchpress_third_attempt_success' %>
+                        <span class="ml-2"><%= f.label :benchpress_third_attempt_result, "成功", for: 'benchpress_third_attempt_success' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :benchpress_third_attempt_result, 'failure', class: 'radio radio-primary', id: 'benchpress_third_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :benchpress_third_attempt_result, "失敗", for: 'benchpress_third_attempt_failure' %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: f.object, attribute: :benchpress_third_attempt_result %>
+          </div>
+        </div>
+        <!-- ボタン -->
+        <div class="form-control mt-6 flex flex-row justify-center">
+          <div>
+            <%= f.submit "次の種目へ", class: 'btn btn-accent btn-sm w-24' %>
+          </div>
+        </div>
+      <% end %>
       <!-- ここまでform_withを使う形に修正 -->
     </div>
   </div>

--- a/app/views/record/comments/edit.html.erb
+++ b/app/views/record/comments/edit.html.erb
@@ -1,11 +1,11 @@
 <% content_for :head do %>
-    <title><%= @competition.name %> | PowerLifter's Log</title>
+  <title><%= @competition.name %> | PowerLifter's Log</title>
 <% end %>
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
       <h1 class="text-2xl text-center mb-5 font-bold">振り返りコメント 編集</h1>
-			  <%= form_with model: @comment, url: competition_comment_path(@competition), method: "patch" do |f| %>
+        <%= form_with model: @comment, url: competition_comment_path(@competition), method: "patch" do |f| %>
           <!-- 振り返りコメント -->
           <label class="form-control mb-6">
             <div class="label p-0 flex justify-start items-center">
@@ -18,7 +18,7 @@
             <div>
               <%= f.submit "更新", class: 'btn btn-accent btn-sm w-24' %>
             </div>
-				  </div>
+          </div>
         <% end %>
     </div>
   </div>

--- a/app/views/record/comments/new.html.erb
+++ b/app/views/record/comments/new.html.erb
@@ -1,24 +1,24 @@
 <% content_for :head do %>
-    <title><%= @competition.name %> | PowerLifter's Log</title>
+  <title><%= @competition.name %> | PowerLifter's Log</title>
 <% end %>
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
       <div class="mb-5 flex justify-center">
-				<ul class="steps">
-					<li class="step step-primary text-[10px]">検量体重</li>
+        <ul class="steps">
+          <li class="step step-primary text-[10px]">検量体重</li>
           <% unless @competition.category == "シングルベンチプレス" %>
-					  <li class="step step-primary text-[10px]">スクワット</li>
+            <li class="step step-primary text-[10px]">スクワット</li>
           <% end %>
-					<li class="step step-primary text-[10px]">ベンチプレス</li>
+          <li class="step step-primary text-[10px]">ベンチプレス</li>
           <% unless @competition.category == "シングルベンチプレス" %>
-					  <li class="step step-primary text-[10px]">デッドリフト</li>
+            <li class="step step-primary text-[10px]">デッドリフト</li>
           <% end %>
-					<li class="step step-primary text-[10px] text-orange-600 font-bold">振り返り<br>コメント</li>
-				</ul>
-			</div>
+          <li class="step step-primary text-[10px] text-orange-600 font-bold">振り返り<br>コメント</li>
+        </ul>
+      </div>
       <h1 class="text-2xl text-center mb-5 font-bold">振り返りコメント</h1>
-			  <%= form_with model: @comment, url: competition_comment_path(@competition)  do |f| %>
+        <%= form_with model: @comment, url: competition_comment_path(@competition)  do |f| %>
           <!-- 振り返りコメント -->
           <label class="form-control mb-6">
             <div class="label p-0 flex justify-start items-center">
@@ -31,7 +31,7 @@
             <div>
               <%= f.submit class: 'btn btn-accent btn-sm w-24' %>
             </div>
-				  </div>
+          </div>
         <% end %>
     </div>
   </div>

--- a/app/views/record/deadlifts/edit.html.erb
+++ b/app/views/record/deadlifts/edit.html.erb
@@ -1,121 +1,121 @@
 <% content_for :head do %>
-    <title><%= @competition.name %> | PowerLifter's Log</title>
+  <title><%= @competition.name %> | PowerLifter's Log</title>
 <% end %>
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
       <h1 class="text-2xl text-center mb-5 font-bold">デッドリフト結果 編集</h1>
-			<%= form_with model: @deadlift, url: competition_deadlift_path(@competition), method: "patch" do |f| %>
-				<!-- デッドリフト試技結果 -->
-				<!-- デッドリフト第１試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :deadlift_first_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_first_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "未試行" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_first_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "成功" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_first_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "失敗" %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_first_attempt_result %>
-					</div>
-				</div>
-				<!-- デッドリフト第2試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :deadlift_second_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_second_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "未試行" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_second_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "成功" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_second_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "失敗" %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_second_attempt_result %>
-					</div>
-				</div>
-				<!-- デッドリフト第3試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :deadlift_third_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_third_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "未試行" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_third_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "成功" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_third_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "失敗" %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_third_attempt_result %>
-					</div>
-				</div>
-				<!-- ボタン -->
-				<div class="form-control mt-6 flex flex-row justify-center">
-					<div>
-						<%= f.submit "更新", class: 'btn btn-accent btn-sm w-24' %>
-					</div>
-				</div>
-			<% end %>
+      <%= form_with model: @deadlift, url: competition_deadlift_path(@competition), method: "patch" do |f| %>
+        <!-- デッドリフト試技結果 -->
+        <!-- デッドリフト第１試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :deadlift_first_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_first_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :deadlift_first_attempt_result, "未試行" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_first_attempt_result, 'success', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :deadlift_first_attempt_result, "成功" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_first_attempt_result, 'failure', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :deadlift_first_attempt_result, "失敗" %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_first_attempt_result %>
+          </div>
+        </div>
+        <!-- デッドリフト第2試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :deadlift_second_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_second_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :deadlift_second_attempt_result, "未試行" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_second_attempt_result, 'success', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :deadlift_second_attempt_result, "成功" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_second_attempt_result, 'failure', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :deadlift_second_attempt_result, "失敗" %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_second_attempt_result %>
+          </div>
+        </div>
+        <!-- デッドリフト第3試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :deadlift_third_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_third_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :deadlift_third_attempt_result, "未試行" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_third_attempt_result, 'success', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :deadlift_third_attempt_result, "成功" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_third_attempt_result, 'failure', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :deadlift_third_attempt_result, "失敗" %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :deadlift_third_attempt_result %>
+          </div>
+        </div>
+        <!-- ボタン -->
+        <div class="form-control mt-6 flex flex-row justify-center">
+          <div>
+            <%= f.submit "更新", class: 'btn btn-accent btn-sm w-24' %>
+          </div>
+        </div>
+      <% end %>
       <!-- ここまでform_withを使う形に修正 -->
     </div>
   </div>

--- a/app/views/record/deadlifts/edit.html.erb
+++ b/app/views/record/deadlifts/edit.html.erb
@@ -25,16 +25,16 @@
             <label class="form-control">
                 <div class="flex justify-between items-center mt-2">
                     <label class="flex items-center">
-                        <%= f.radio_button :deadlift_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :deadlift_first_attempt_result, "未試行" %></span>
+                        <%= f.radio_button :deadlift_first_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'deadlift_first_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :deadlift_first_attempt_result, "未試行", for: 'deadlift_first_attempt_not_attempted' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :deadlift_first_attempt_result, 'success', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :deadlift_first_attempt_result, "成功" %></span>
+                        <%= f.radio_button :deadlift_first_attempt_result, 'success', class: 'radio radio-primary', id: 'deadlift_first_attempt_success' %>
+                        <span class="ml-2"><%= f.label :deadlift_first_attempt_result, "成功", for: 'deadlift_first_attempt_success' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :deadlift_first_attempt_result, 'failure', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :deadlift_first_attempt_result, "失敗" %></span>
+                        <%= f.radio_button :deadlift_first_attempt_result, 'failure', class: 'radio radio-primary', id: 'deadlift_first_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :deadlift_first_attempt_result, "失敗", for: 'deadlift_first_attempt_failure' %></span>
                     </label>
                 </div>
             </label>
@@ -59,16 +59,16 @@
             <label class="form-control">
                 <div class="flex justify-between items-center mt-2">
                     <label class="flex items-center">
-                        <%= f.radio_button :deadlift_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :deadlift_second_attempt_result, "未試行" %></span>
+                        <%= f.radio_button :deadlift_second_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'deadlift_second_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :deadlift_second_attempt_result, "未試行", for: 'deadlift_second_attempt_not_attempted' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :deadlift_second_attempt_result, 'success', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :deadlift_second_attempt_result, "成功" %></span>
+                        <%= f.radio_button :deadlift_second_attempt_result, 'success', class: 'radio radio-primary', id: 'deadlift_second_attempt_success' %>
+                        <span class="ml-2"><%= f.label :deadlift_second_attempt_result, "成功", for: 'deadlift_second_attempt_success' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :deadlift_second_attempt_result, 'failure', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :deadlift_second_attempt_result, "失敗" %></span>
+                        <%= f.radio_button :deadlift_second_attempt_result, 'failure', class: 'radio radio-primary', id: 'deadlift_second_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :deadlift_second_attempt_result, "失敗", for: 'deadlift_second_attempt_failure' %></span>
                     </label>
                 </div>
             </label>
@@ -93,16 +93,16 @@
             <label class="form-control">
                 <div class="flex justify-between items-center mt-2">
                     <label class="flex items-center">
-                        <%= f.radio_button :deadlift_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :deadlift_third_attempt_result, "未試行" %></span>
+                        <%= f.radio_button :deadlift_third_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'deadlift_third_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :deadlift_third_attempt_result, "未試行", for: 'deadlift_third_attempt_not_attempted' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :deadlift_third_attempt_result, 'success', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :deadlift_third_attempt_result, "成功" %></span>
+                        <%= f.radio_button :deadlift_third_attempt_result, 'success', class: 'radio radio-primary', id: 'deadlift_third_attempt_success' %>
+                        <span class="ml-2"><%= f.label :deadlift_third_attempt_result, "成功", for: 'deadlift_third_attempt_success' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :deadlift_third_attempt_result, 'failure', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :deadlift_third_attempt_result, "失敗" %></span>
+                        <%= f.radio_button :deadlift_third_attempt_result, 'failure', class: 'radio radio-primary', id: 'deadlift_third_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :deadlift_third_attempt_result, "失敗", for: 'deadlift_third_attempt_failure' %></span>
                     </label>
                 </div>
             </label>

--- a/app/views/record/deadlifts/new.html.erb
+++ b/app/views/record/deadlifts/new.html.erb
@@ -1,130 +1,130 @@
 <% content_for :head do %>
-    <title><%= @competition.name %> | PowerLifter's Log</title>
+  <title><%= @competition.name %> | PowerLifter's Log</title>
 <% end %>
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
       <div class="mb-5">
-				<ul class="steps">
-					<li class="step step-primary text-[10px]">検量体重</li>
-					<li class="step step-primary text-[10px]">スクワット</li>
-					<li class="step step-primary text-[10px]">ベンチプレス</li>
-					<li class="step step-primary text-[10px] text-orange-600 font-bold">デッドリフト</li>
-					<li class="step text-[10px]">振り返り<br>コメント</li>
-				</ul>
-			</div>
+        <ul class="steps">
+          <li class="step step-primary text-[10px]">検量体重</li>
+          <li class="step step-primary text-[10px]">スクワット</li>
+          <li class="step step-primary text-[10px]">ベンチプレス</li>
+          <li class="step step-primary text-[10px] text-orange-600 font-bold">デッドリフト</li>
+          <li class="step text-[10px]">振り返り<br>コメント</li>
+        </ul>
+      </div>
       <h1 class="text-2xl text-center mb-5 font-bold">デッドリフト結果 登録</h1>
-			<%= form_with model: @deadlift, url: competition_deadlift_path(@competition)  do |f| %>
-				<!-- デッドリフト試技結果 -->
-				<!-- デッドリフト第１試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :deadlift_first_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: f.object, attribute: :deadlift_first_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_first_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'deadlift_first_attempt_not_attempted' %>
-												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "未試行", for: 'deadlift_first_attempt_not_attempted' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_first_attempt_result, 'success', class: 'radio radio-primary', id: 'deadlift_first_attempt_success' %>
-												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "成功", for: 'deadlift_first_attempt_success' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_first_attempt_result, 'failure', class: 'radio radio-primary', id: 'deadlift_first_attempt_failure' %>
-												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "失敗", for: 'deadlift_first_attempt_failure' %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: f.object, attribute: :deadlift_first_attempt_result %>
-					</div>
-				</div>
-				<!-- デッドリフト第2試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :deadlift_second_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: f.object, attribute: :deadlift_second_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_second_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'deadlift_second_attempt_not_attempted' %>
-												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "未試行", for: 'deadlift_second_attempt_not_attempted' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_second_attempt_result, 'success', class: 'radio radio-primary', id: 'deadlift_second_attempt_success' %>
-												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "成功", for: 'deadlift_second_attempt_success' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_second_attempt_result, 'failure', class: 'radio radio-primary', id: 'deadlift_second_attempt_failure' %>
-												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "失敗", for: 'deadlift_second_attempt_failure' %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: f.object, attribute: :deadlift_second_attempt_result %>
-					</div>
-				</div>
-				<!-- デッドリフト第3試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :deadlift_third_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: f.object, attribute: :deadlift_third_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_third_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'deadlift_third_attempt_not_attempted' %>
-												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "未試行", for: 'deadlift_third_attempt_not_attempted' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_third_attempt_result, 'success', class: 'radio radio-primary', id: 'deadlift_third_attempt_success' %>
-												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "成功", for: 'deadlift_third_attempt_success' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :deadlift_third_attempt_result, 'failure', class: 'radio radio-primary', id: 'deadlift_third_attempt_failure' %>
-												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "失敗", for: 'deadlift_third_attempt_failure' %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: f.object, attribute: :deadlift_third_attempt_result %>
-					</div>
-				</div>
-				<!-- ボタン -->
-				<div class="form-control mt-6 flex flex-row justify-center">
-					<div>
-						<%= f.submit "次の種目へ", class: 'btn btn-accent btn-sm w-24' %>
-					</div>
-				</div>
-			<% end %>
+      <%= form_with model: @deadlift, url: competition_deadlift_path(@competition)  do |f| %>
+        <!-- デッドリフト試技結果 -->
+        <!-- デッドリフト第１試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :deadlift_first_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :deadlift_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_first_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_first_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'deadlift_first_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :deadlift_first_attempt_result, "未試行", for: 'deadlift_first_attempt_not_attempted' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_first_attempt_result, 'success', class: 'radio radio-primary', id: 'deadlift_first_attempt_success' %>
+                        <span class="ml-2"><%= f.label :deadlift_first_attempt_result, "成功", for: 'deadlift_first_attempt_success' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_first_attempt_result, 'failure', class: 'radio radio-primary', id: 'deadlift_first_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :deadlift_first_attempt_result, "失敗", for: 'deadlift_first_attempt_failure' %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_first_attempt_result %>
+          </div>
+        </div>
+        <!-- デッドリフト第2試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :deadlift_second_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :deadlift_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_second_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_second_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'deadlift_second_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :deadlift_second_attempt_result, "未試行", for: 'deadlift_second_attempt_not_attempted' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_second_attempt_result, 'success', class: 'radio radio-primary', id: 'deadlift_second_attempt_success' %>
+                        <span class="ml-2"><%= f.label :deadlift_second_attempt_result, "成功", for: 'deadlift_second_attempt_success' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_second_attempt_result, 'failure', class: 'radio radio-primary', id: 'deadlift_second_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :deadlift_second_attempt_result, "失敗", for: 'deadlift_second_attempt_failure' %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_second_attempt_result %>
+          </div>
+        </div>
+        <!-- デッドリフト第3試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :deadlift_third_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :deadlift_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_third_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_third_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'deadlift_third_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :deadlift_third_attempt_result, "未試行", for: 'deadlift_third_attempt_not_attempted' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_third_attempt_result, 'success', class: 'radio radio-primary', id: 'deadlift_third_attempt_success' %>
+                        <span class="ml-2"><%= f.label :deadlift_third_attempt_result, "成功", for: 'deadlift_third_attempt_success' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :deadlift_third_attempt_result, 'failure', class: 'radio radio-primary', id: 'deadlift_third_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :deadlift_third_attempt_result, "失敗", for: 'deadlift_third_attempt_failure' %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: f.object, attribute: :deadlift_third_attempt_result %>
+          </div>
+        </div>
+        <!-- ボタン -->
+        <div class="form-control mt-6 flex flex-row justify-center">
+          <div>
+            <%= f.submit "次の種目へ", class: 'btn btn-accent btn-sm w-24' %>
+          </div>
+        </div>
+      <% end %>
       <!-- ここまでform_withを使う形に修正 -->
     </div>
   </div>

--- a/app/views/record/deadlifts/new.html.erb
+++ b/app/views/record/deadlifts/new.html.erb
@@ -34,16 +34,16 @@
 						<label class="form-control">
 								<div class="flex justify-between items-center mt-2">
 										<label class="flex items-center">
-												<%= f.radio_button :deadlift_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "未試行" %></span>
+												<%= f.radio_button :deadlift_first_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'deadlift_first_attempt_not_attempted' %>
+												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "未試行", for: 'deadlift_first_attempt_not_attempted' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :deadlift_first_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "成功" %></span>
+												<%= f.radio_button :deadlift_first_attempt_result, 'success', class: 'radio radio-primary', id: 'deadlift_first_attempt_success' %>
+												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "成功", for: 'deadlift_first_attempt_success' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :deadlift_first_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "失敗" %></span>
+												<%= f.radio_button :deadlift_first_attempt_result, 'failure', class: 'radio radio-primary', id: 'deadlift_first_attempt_failure' %>
+												<span class="ml-2"><%= f.label :deadlift_first_attempt_result, "失敗", for: 'deadlift_first_attempt_failure' %></span>
 										</label>
 								</div>
 						</label>
@@ -68,16 +68,16 @@
 						<label class="form-control">
 								<div class="flex justify-between items-center mt-2">
 										<label class="flex items-center">
-												<%= f.radio_button :deadlift_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "未試行" %></span>
+												<%= f.radio_button :deadlift_second_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'deadlift_second_attempt_not_attempted' %>
+												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "未試行", for: 'deadlift_second_attempt_not_attempted' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :deadlift_second_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "成功" %></span>
+												<%= f.radio_button :deadlift_second_attempt_result, 'success', class: 'radio radio-primary', id: 'deadlift_second_attempt_success' %>
+												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "成功", for: 'deadlift_second_attempt_success' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :deadlift_second_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "失敗" %></span>
+												<%= f.radio_button :deadlift_second_attempt_result, 'failure', class: 'radio radio-primary', id: 'deadlift_second_attempt_failure' %>
+												<span class="ml-2"><%= f.label :deadlift_second_attempt_result, "失敗", for: 'deadlift_second_attempt_failure' %></span>
 										</label>
 								</div>
 						</label>
@@ -102,16 +102,16 @@
 						<label class="form-control">
 								<div class="flex justify-between items-center mt-2">
 										<label class="flex items-center">
-												<%= f.radio_button :deadlift_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "未試行" %></span>
+												<%= f.radio_button :deadlift_third_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'deadlift_third_attempt_not_attempted' %>
+												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "未試行", for: 'deadlift_third_attempt_not_attempted' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :deadlift_third_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "成功" %></span>
+												<%= f.radio_button :deadlift_third_attempt_result, 'success', class: 'radio radio-primary', id: 'deadlift_third_attempt_success' %>
+												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "成功", for: 'deadlift_third_attempt_success' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :deadlift_third_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "失敗" %></span>
+												<%= f.radio_button :deadlift_third_attempt_result, 'failure', class: 'radio radio-primary', id: 'deadlift_third_attempt_failure' %>
+												<span class="ml-2"><%= f.label :deadlift_third_attempt_result, "失敗", for: 'deadlift_third_attempt_failure' %></span>
 										</label>
 								</div>
 						</label>

--- a/app/views/record/squats/edit.html.erb
+++ b/app/views/record/squats/edit.html.erb
@@ -1,121 +1,121 @@
 <% content_for :head do %>
-    <title><%= @competition.name %> | PowerLifter's Log</title>
+  <title><%= @competition.name %> | PowerLifter's Log</title>
 <% end %>
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
       <h1 class="text-2xl text-center mb-5 font-bold">スクワット結果 登録</h1>
-			<%= form_with model: @squat, url: competition_squat_path(@competition), method: "patch" do |f| %>
-				<!-- スクワット試技結果 -->
-				<!-- スクワット第１試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :squat_first_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :squat_first_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :squat_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_first_attempt_result, "未試行" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :squat_first_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_first_attempt_result, "成功" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :squat_first_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_first_attempt_result, "失敗" %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :squat_first_attempt_result %>
-					</div>
-				</div>
-				<!-- スクワット第2試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :squat_second_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :squat_second_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :squat_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_second_attempt_result, "未試行" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :squat_second_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_second_attempt_result, "成功" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :squat_second_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_second_attempt_result, "失敗" %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :squat_second_attempt_result %>
-					</div>
-				</div>
-				<!-- スクワット第3試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :squat_third_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :squat_third_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :squat_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_third_attempt_result, "未試行" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :squat_third_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_third_attempt_result, "成功" %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :squat_third_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_third_attempt_result, "失敗" %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: @competition_record, attribute: :squat_third_attempt_result %>
-					</div>
-				</div>
-				<!-- ボタン -->
-				<div class="form-control mt-6 flex flex-row justify-center">
-					<div>
-						<%= f.submit "更新", class: 'btn btn-accent btn-sm w-24' %>
-					</div>
-				</div>
-			<% end %>
+      <%= form_with model: @squat, url: competition_squat_path(@competition), method: "patch" do |f| %>
+        <!-- スクワット試技結果 -->
+        <!-- スクワット第１試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :squat_first_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :squat_first_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :squat_first_attempt_result, "未試行" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_first_attempt_result, 'success', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :squat_first_attempt_result, "成功" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_first_attempt_result, 'failure', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :squat_first_attempt_result, "失敗" %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :squat_first_attempt_result %>
+          </div>
+        </div>
+        <!-- スクワット第2試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :squat_second_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :squat_second_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :squat_second_attempt_result, "未試行" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_second_attempt_result, 'success', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :squat_second_attempt_result, "成功" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_second_attempt_result, 'failure', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :squat_second_attempt_result, "失敗" %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :squat_second_attempt_result %>
+          </div>
+        </div>
+        <!-- スクワット第3試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :squat_third_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :squat_third_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :squat_third_attempt_result, "未試行" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_third_attempt_result, 'success', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :squat_third_attempt_result, "成功" %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_third_attempt_result, 'failure', class: 'radio radio-primary' %>
+                        <span class="ml-2"><%= f.label :squat_third_attempt_result, "失敗" %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: @competition_record, attribute: :squat_third_attempt_result %>
+          </div>
+        </div>
+        <!-- ボタン -->
+        <div class="form-control mt-6 flex flex-row justify-center">
+          <div>
+            <%= f.submit "更新", class: 'btn btn-accent btn-sm w-24' %>
+          </div>
+        </div>
+      <% end %>
       <!-- ここまでform_withを使う形に修正 -->
     </div>
   </div>

--- a/app/views/record/squats/edit.html.erb
+++ b/app/views/record/squats/edit.html.erb
@@ -25,16 +25,16 @@
             <label class="form-control">
                 <div class="flex justify-between items-center mt-2">
                     <label class="flex items-center">
-                        <%= f.radio_button :squat_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :squat_first_attempt_result, "未試行" %></span>
+                        <%= f.radio_button :squat_first_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'squat_first_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :squat_first_attempt_result, "未試行", for: 'squat_first_attempt_not_attempted' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :squat_first_attempt_result, 'success', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :squat_first_attempt_result, "成功" %></span>
+                        <%= f.radio_button :squat_first_attempt_result, 'success', class: 'radio radio-primary', id: 'squat_first_attempt_success' %>
+                        <span class="ml-2"><%= f.label :squat_first_attempt_result, "成功", for: 'squat_first_attempt_success' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :squat_first_attempt_result, 'failure', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :squat_first_attempt_result, "失敗" %></span>
+                        <%= f.radio_button :squat_first_attempt_result, 'failure', class: 'radio radio-primary', id: 'squat_first_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :squat_first_attempt_result, "失敗", for: 'squat_first_attempt_failure' %></span>
                     </label>
                 </div>
             </label>
@@ -59,16 +59,16 @@
             <label class="form-control">
                 <div class="flex justify-between items-center mt-2">
                     <label class="flex items-center">
-                        <%= f.radio_button :squat_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :squat_second_attempt_result, "未試行" %></span>
+                        <%= f.radio_button :squat_second_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'squat_second_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :squat_second_attempt_result, "未試行", for: 'squat_second_attempt_not_attempted' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :squat_second_attempt_result, 'success', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :squat_second_attempt_result, "成功" %></span>
+                        <%= f.radio_button :squat_second_attempt_result, 'success', class: 'radio radio-primary', id: 'squat_second_attempt_success' %>
+                        <span class="ml-2"><%= f.label :squat_second_attempt_result, "成功", for: 'squat_second_attempt_success' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :squat_second_attempt_result, 'failure', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :squat_second_attempt_result, "失敗" %></span>
+                        <%= f.radio_button :squat_second_attempt_result, 'failure', class: 'radio radio-primary', id: 'squat_second_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :squat_second_attempt_result, "失敗", for: 'squat_second_attempt_failure' %></span>
                     </label>
                 </div>
             </label>
@@ -93,16 +93,16 @@
             <label class="form-control">
                 <div class="flex justify-between items-center mt-2">
                     <label class="flex items-center">
-                        <%= f.radio_button :squat_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :squat_third_attempt_result, "未試行" %></span>
+                        <%= f.radio_button :squat_third_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'squat_third_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :squat_third_attempt_result, "未試行", for: 'squat_third_attempt_not_attempted' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :squat_third_attempt_result, 'success', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :squat_third_attempt_result, "成功" %></span>
+                        <%= f.radio_button :squat_third_attempt_result, 'success', class: 'radio radio-primary', id: 'squat_third_attempt_success' %>
+                        <span class="ml-2"><%= f.label :squat_third_attempt_result, "成功", for: 'squat_third_attempt_success' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :squat_third_attempt_result, 'failure', class: 'radio radio-primary' %>
-                        <span class="ml-2"><%= f.label :squat_third_attempt_result, "失敗" %></span>
+                        <%= f.radio_button :squat_third_attempt_result, 'failure', class: 'radio radio-primary', id: 'squat_third_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :squat_third_attempt_result, "失敗", for: 'squat_third_attempt_failure' %></span>
                     </label>
                 </div>
             </label>

--- a/app/views/record/squats/new.html.erb
+++ b/app/views/record/squats/new.html.erb
@@ -1,130 +1,130 @@
 <% content_for :head do %>
-    <title><%= @competition.name %> | PowerLifter's Log</title>
+  <title><%= @competition.name %> | PowerLifter's Log</title>
 <% end %>
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
       <div class="mb-5">
-				<ul class="steps">
-					<li class="step step-primary text-[10px]">検量体重</li>
-					<li class="step step-primary text-[10px] text-orange-600 font-bold">スクワット</li>
-					<li class="step text-[10px]">ベンチプレス</li>
-					<li class="step text-[10px]">デッドリフト</li>
-					<li class="step text-[10px]">振り返り<br>コメント</li>
-				</ul>
-			</div>
+        <ul class="steps">
+          <li class="step step-primary text-[10px]">検量体重</li>
+          <li class="step step-primary text-[10px] text-orange-600 font-bold">スクワット</li>
+          <li class="step text-[10px]">ベンチプレス</li>
+          <li class="step text-[10px]">デッドリフト</li>
+          <li class="step text-[10px]">振り返り<br>コメント</li>
+        </ul>
+      </div>
       <h1 class="text-2xl text-center mb-5 font-bold">スクワット結果登録</h1>
-			<%= form_with model: @squat, url: competition_squat_path(@competition)  do |f| %>
-				<!-- スクワット試技結果 -->
-				<!-- スクワット第１試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :squat_first_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: f.object, attribute: :squat_first_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :squat_first_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'squat_first_attempt_not_attempted' %>
-												<span class="ml-2"><%= f.label :squat_first_attempt_result, "未試行", for: 'squat_first_attempt_not_attempted' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :squat_first_attempt_result, 'success', class: 'radio radio-primary', id: 'squat_first_attempt_success' %>
-												<span class="ml-2"><%= f.label :squat_first_attempt_result, "成功", for: 'squat_first_attempt_success' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :squat_first_attempt_result, 'failure', class: 'radio radio-primary', id: 'squat_first_attempt_failure' %>
-												<span class="ml-2"><%= f.label :squat_first_attempt_result, "失敗", for: 'squat_first_attempt_failure' %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: f.object, attribute: :squat_first_attempt_result %>
-					</div>
-				</div>
-				<!-- スクワット第2試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :squat_second_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: f.object, attribute: :squat_second_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :squat_second_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'squat_second_attempt_not_attempted' %>
-												<span class="ml-2"><%= f.label :squat_second_attempt_result, "未試行", for: 'squat_second_attempt_not_attempted' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :squat_second_attempt_result, 'success', class: 'radio radio-primary', id: 'squat_second_attempt_success' %>
-												<span class="ml-2"><%= f.label :squat_second_attempt_result, "成功", for: 'squat_second_attempt_success' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :squat_second_attempt_result, 'failure', class: 'radio radio-primary', id: 'squat_second_attempt_failure'  %>
-												<span class="ml-2"><%= f.label :squat_second_attempt_result, "失敗", for: 'squat_second_attempt_failure' %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: f.object, attribute: :squat_second_attempt_result %>
-					</div>
-				</div>
-				<!-- スクワット第3試技 -->
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<!-- 重量-->
-					<div class="flex flex-col mb-3">
-						<div class="flex justify-between">
-							<%= f.label :squat_third_attempt, class: 'text-xl font-semibold' %>
-							<label class="form-control flex flex-row">
-								<%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
-								<span>kg</span>
-							</label>
-						</div>
-						<%= render 'shared/error_messages', object: f.object, attribute: :squat_third_attempt %>
-					</div>
-					<!--判定-->
-					<div class="flex flex-col mb-3">
-						<label class="form-control">
-								<div class="flex justify-between items-center mt-2">
-										<label class="flex items-center">
-												<%= f.radio_button :squat_third_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'squat_third_attempt_not_attempted' %>
-												<span class="ml-2"><%= f.label :squat_third_attempt_result, "未試行", for: 'squat_third_attempt_not_attempted' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :squat_third_attempt_result, 'success', class: 'radio radio-primary', id: 'squat_third_attempt_success' %>
-												<span class="ml-2"><%= f.label :squat_third_attempt_result, "成功", for: 'squat_third_attempt_success' %></span>
-										</label>
-										<label class="flex items-center">
-												<%= f.radio_button :squat_third_attempt_result, 'failure', class: 'radio radio-primary', id: 'squat_third_attempt_failure' %>
-												<span class="ml-2"><%= f.label :squat_third_attempt_result, "失敗", for: 'squat_third_attempt_failure' %></span>
-										</label>
-								</div>
-						</label>
-						<%= render 'shared/error_messages', object: f.object, attribute: :squat_third_attempt_result %>
-					</div>
-				</div>
-				<!-- ボタン -->
-				<div class="form-control mt-6 flex flex-row justify-center">
-					<div>
-						<%= f.submit "次の種目へ", class: 'btn btn-accent btn-sm w-24' %>
-					</div>
-				</div>
-			<% end %>
+      <%= form_with model: @squat, url: competition_squat_path(@competition)  do |f| %>
+        <!-- スクワット試技結果 -->
+        <!-- スクワット第１試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :squat_first_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :squat_first_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: f.object, attribute: :squat_first_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_first_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'squat_first_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :squat_first_attempt_result, "未試行", for: 'squat_first_attempt_not_attempted' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_first_attempt_result, 'success', class: 'radio radio-primary', id: 'squat_first_attempt_success' %>
+                        <span class="ml-2"><%= f.label :squat_first_attempt_result, "成功", for: 'squat_first_attempt_success' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_first_attempt_result, 'failure', class: 'radio radio-primary', id: 'squat_first_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :squat_first_attempt_result, "失敗", for: 'squat_first_attempt_failure' %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: f.object, attribute: :squat_first_attempt_result %>
+          </div>
+        </div>
+        <!-- スクワット第2試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :squat_second_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :squat_second_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: f.object, attribute: :squat_second_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_second_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'squat_second_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :squat_second_attempt_result, "未試行", for: 'squat_second_attempt_not_attempted' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_second_attempt_result, 'success', class: 'radio radio-primary', id: 'squat_second_attempt_success' %>
+                        <span class="ml-2"><%= f.label :squat_second_attempt_result, "成功", for: 'squat_second_attempt_success' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_second_attempt_result, 'failure', class: 'radio radio-primary', id: 'squat_second_attempt_failure'  %>
+                        <span class="ml-2"><%= f.label :squat_second_attempt_result, "失敗", for: 'squat_second_attempt_failure' %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: f.object, attribute: :squat_second_attempt_result %>
+          </div>
+        </div>
+        <!-- スクワット第3試技 -->
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <!-- 重量-->
+          <div class="flex flex-col mb-3">
+            <div class="flex justify-between">
+              <%= f.label :squat_third_attempt, class: 'text-xl font-semibold' %>
+              <label class="form-control flex flex-row">
+                <%= f.text_field :squat_third_attempt, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder: "重量", inputmode: "decimal" %>
+                <span>kg</span>
+              </label>
+            </div>
+            <%= render 'shared/error_messages', object: f.object, attribute: :squat_third_attempt %>
+          </div>
+          <!--判定-->
+          <div class="flex flex-col mb-3">
+            <label class="form-control">
+                <div class="flex justify-between items-center mt-2">
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_third_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'squat_third_attempt_not_attempted' %>
+                        <span class="ml-2"><%= f.label :squat_third_attempt_result, "未試行", for: 'squat_third_attempt_not_attempted' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_third_attempt_result, 'success', class: 'radio radio-primary', id: 'squat_third_attempt_success' %>
+                        <span class="ml-2"><%= f.label :squat_third_attempt_result, "成功", for: 'squat_third_attempt_success' %></span>
+                    </label>
+                    <label class="flex items-center">
+                        <%= f.radio_button :squat_third_attempt_result, 'failure', class: 'radio radio-primary', id: 'squat_third_attempt_failure' %>
+                        <span class="ml-2"><%= f.label :squat_third_attempt_result, "失敗", for: 'squat_third_attempt_failure' %></span>
+                    </label>
+                </div>
+            </label>
+            <%= render 'shared/error_messages', object: f.object, attribute: :squat_third_attempt_result %>
+          </div>
+        </div>
+        <!-- ボタン -->
+        <div class="form-control mt-6 flex flex-row justify-center">
+          <div>
+            <%= f.submit "次の種目へ", class: 'btn btn-accent btn-sm w-24' %>
+          </div>
+        </div>
+      <% end %>
       <!-- ここまでform_withを使う形に修正 -->
     </div>
   </div>

--- a/app/views/record/squats/new.html.erb
+++ b/app/views/record/squats/new.html.erb
@@ -76,7 +76,7 @@
                         <span class="ml-2"><%= f.label :squat_second_attempt_result, "成功", for: 'squat_second_attempt_success' %></span>
                     </label>
                     <label class="flex items-center">
-                        <%= f.radio_button :squat_second_attempt_result, 'failure', class: 'radio radio-primary', id: 'squat_second_attempt_failure'  %>
+                        <%= f.radio_button :squat_second_attempt_result, 'failure', class: 'radio radio-primary', id: 'squat_second_attempt_failure' %>
                         <span class="ml-2"><%= f.label :squat_second_attempt_result, "失敗", for: 'squat_second_attempt_failure' %></span>
                     </label>
                 </div>

--- a/app/views/record/squats/new.html.erb
+++ b/app/views/record/squats/new.html.erb
@@ -34,16 +34,16 @@
 						<label class="form-control">
 								<div class="flex justify-between items-center mt-2">
 										<label class="flex items-center">
-												<%= f.radio_button :squat_first_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_first_attempt_result, "未試行" %></span>
+												<%= f.radio_button :squat_first_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'squat_first_attempt_not_attempted' %>
+												<span class="ml-2"><%= f.label :squat_first_attempt_result, "未試行", for: 'squat_first_attempt_not_attempted' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :squat_first_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_first_attempt_result, "成功" %></span>
+												<%= f.radio_button :squat_first_attempt_result, 'success', class: 'radio radio-primary', id: 'squat_first_attempt_success' %>
+												<span class="ml-2"><%= f.label :squat_first_attempt_result, "成功", for: 'squat_first_attempt_success' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :squat_first_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_first_attempt_result, "失敗" %></span>
+												<%= f.radio_button :squat_first_attempt_result, 'failure', class: 'radio radio-primary', id: 'squat_first_attempt_failure' %>
+												<span class="ml-2"><%= f.label :squat_first_attempt_result, "失敗", for: 'squat_first_attempt_failure' %></span>
 										</label>
 								</div>
 						</label>
@@ -68,16 +68,16 @@
 						<label class="form-control">
 								<div class="flex justify-between items-center mt-2">
 										<label class="flex items-center">
-												<%= f.radio_button :squat_second_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_second_attempt_result, "未試行" %></span>
+												<%= f.radio_button :squat_second_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'squat_second_attempt_not_attempted' %>
+												<span class="ml-2"><%= f.label :squat_second_attempt_result, "未試行", for: 'squat_second_attempt_not_attempted' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :squat_second_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_second_attempt_result, "成功" %></span>
+												<%= f.radio_button :squat_second_attempt_result, 'success', class: 'radio radio-primary', id: 'squat_second_attempt_success' %>
+												<span class="ml-2"><%= f.label :squat_second_attempt_result, "成功", for: 'squat_second_attempt_success' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :squat_second_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_second_attempt_result, "失敗" %></span>
+												<%= f.radio_button :squat_second_attempt_result, 'failure', class: 'radio radio-primary', id: 'squat_second_attempt_failure'  %>
+												<span class="ml-2"><%= f.label :squat_second_attempt_result, "失敗", for: 'squat_second_attempt_failure' %></span>
 										</label>
 								</div>
 						</label>
@@ -102,16 +102,16 @@
 						<label class="form-control">
 								<div class="flex justify-between items-center mt-2">
 										<label class="flex items-center">
-												<%= f.radio_button :squat_third_attempt_result, 'not_attempted', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_third_attempt_result, "未試行" %></span>
+												<%= f.radio_button :squat_third_attempt_result, 'not_attempted', class: 'radio radio-primary', id: 'squat_third_attempt_not_attempted' %>
+												<span class="ml-2"><%= f.label :squat_third_attempt_result, "未試行", for: 'squat_third_attempt_not_attempted' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :squat_third_attempt_result, 'success', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_third_attempt_result, "成功" %></span>
+												<%= f.radio_button :squat_third_attempt_result, 'success', class: 'radio radio-primary', id: 'squat_third_attempt_success' %>
+												<span class="ml-2"><%= f.label :squat_third_attempt_result, "成功", for: 'squat_third_attempt_success' %></span>
 										</label>
 										<label class="flex items-center">
-												<%= f.radio_button :squat_third_attempt_result, 'failure', class: 'radio radio-primary' %>
-												<span class="ml-2"><%= f.label :squat_third_attempt_result, "失敗" %></span>
+												<%= f.radio_button :squat_third_attempt_result, 'failure', class: 'radio radio-primary', id: 'squat_third_attempt_failure' %>
+												<span class="ml-2"><%= f.label :squat_third_attempt_result, "失敗", for: 'squat_third_attempt_failure' %></span>
 										</label>
 								</div>
 						</label>

--- a/app/views/record/weigh_ins/edit.html.erb
+++ b/app/views/record/weigh_ins/edit.html.erb
@@ -1,31 +1,31 @@
 <% content_for :head do %>
-    <title><%= @competition.name %> | PowerLifter's Log</title>
+  <title><%= @competition.name %> | PowerLifter's Log</title>
 <% end %>
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
       <h1 class="text-2xl text-center mb-5 font-bold">検量体重 編集</h1>
-			<%= form_with model: @weigh_in, url: competition_weigh_in_path(@competition), method: "patch" do |f| %>
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<div class="flex justify-between">
-						<div class="label p-0 flex justify-start items-center">
-							<%= f.label :weight, class: 'mr-2 font-semibold'%>
-							<p class="text-red-500">(必須)</p>
-						</div>
-						<label class="form-control flex flex-row">
-							<%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder:"検量体重", inputmode: "decimal"%>
-							<span>kg</span>
-						</label>
-					</div>
-					<%= render 'shared/error_messages', object: @competition_record, attribute: :weight %>
-				</div>
-			<!-- ボタン -->
-			<div class="form-control mt-6 flex flex-row justify-center">
-				<div>
-					<%= f.submit "更新", class: 'btn btn-accent btn-sm w-24' %>
-				</div>
-			</div>
-			<% end %>
+      <%= form_with model: @weigh_in, url: competition_weigh_in_path(@competition), method: "patch" do |f| %>
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <div class="flex justify-between">
+            <div class="label p-0 flex justify-start items-center">
+              <%= f.label :weight, class: 'mr-2 font-semibold'%>
+              <p class="text-red-500">(必須)</p>
+            </div>
+            <label class="form-control flex flex-row">
+              <%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder:"検量体重", inputmode: "decimal"%>
+              <span>kg</span>
+            </label>
+          </div>
+          <%= render 'shared/error_messages', object: @competition_record, attribute: :weight %>
+        </div>
+      <!-- ボタン -->
+      <div class="form-control mt-6 flex flex-row justify-center">
+        <div>
+          <%= f.submit "更新", class: 'btn btn-accent btn-sm w-24' %>
+        </div>
+      </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/record/weigh_ins/new.html.erb
+++ b/app/views/record/weigh_ins/new.html.erb
@@ -1,45 +1,45 @@
 <% content_for :head do %>
-    <title><%= @competition.name %> | PowerLifter's Log</title>
+  <title><%= @competition.name %> | PowerLifter's Log</title>
 <% end %>
 <div class="hero min-h-screen bg-white">
   <div class="hero-content flex-col">
     <div class="items-center mx-auto max-w-80 min-w-80">
       <div class="mb-5 flex justify-center">
-				<ul class="steps">
-					<li class="step step-primary text-[10px] text-orange-600 font-bold">検量体重</li>
-					<% unless @competition.category == "シングルベンチプレス" %>
-						<li class="step text-[10px]">スクワット</li>
-					<% end %>
-					<li class="step text-[10px]">ベンチプレス</li>
-					<% unless @competition.category == "シングルベンチプレス" %>
-						<li class="step text-[10px]">デッドリフト</li>
-					<% end %>
-					<li class="step text-[10px]">振り返り<br>コメント</li>
-				</ul>
-			</div>
+        <ul class="steps">
+          <li class="step step-primary text-[10px] text-orange-600 font-bold">検量体重</li>
+          <% unless @competition.category == "シングルベンチプレス" %>
+            <li class="step text-[10px]">スクワット</li>
+          <% end %>
+          <li class="step text-[10px]">ベンチプレス</li>
+          <% unless @competition.category == "シングルベンチプレス" %>
+            <li class="step text-[10px]">デッドリフト</li>
+          <% end %>
+          <li class="step text-[10px]">振り返り<br>コメント</li>
+        </ul>
+      </div>
       <h1 class="text-2xl text-center mb-5 font-bold">検量体重登録</h1>
-			<%= form_with model: @weigh_in, url: competition_weigh_in_path(@competition)  do |f| %>
-				<div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
-					<div class="flex justify-between">
-						<div class="label p-0 flex justify-start items-center">
-							<%= f.label :weight, class: 'mr-2 font-semibold'%>
-							<p class="text-red-500">(必須)</p>
-						</div>
-						<label class="form-control flex flex-row">
-							<%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder:"検量体重", inputmode: "decimal"%>
-							<span>kg</span>
-						</label>
-					</div>
-					<%= render 'shared/error_messages', object: f.object, attribute: :weight %>
-					<%= render 'shared/error_messages', object: f.object, attribute: :competition_id %>
-				</div>
-			<!-- ボタン -->
-			<div class="form-control mt-6 flex flex-row justify-center">
-				<div>
-					<%= f.submit "次の種目へ", class: 'btn btn-accent btn-sm w-24' %>
-				</div>
-			</div>
-			<% end %>
+      <%= form_with model: @weigh_in, url: competition_weigh_in_path(@competition)  do |f| %>
+        <div class="flex flex-col mb-5 border-dashed border-2 border-neutral-300 rounded-lg p-4">
+          <div class="flex justify-between">
+            <div class="label p-0 flex justify-start items-center">
+              <%= f.label :weight, class: 'mr-2 font-semibold'%>
+              <p class="text-red-500">(必須)</p>
+            </div>
+            <label class="form-control flex flex-row">
+              <%= f.text_field :weight, class: 'input input-bordered input-sm rounded w-32 mr-2 text-base', placeholder:"検量体重", inputmode: "decimal"%>
+              <span>kg</span>
+            </label>
+          </div>
+          <%= render 'shared/error_messages', object: f.object, attribute: :weight %>
+          <%= render 'shared/error_messages', object: f.object, attribute: :competition_id %>
+        </div>
+      <!-- ボタン -->
+      <div class="form-control mt-6 flex flex-row justify-center">
+        <div>
+          <%= f.submit "次の種目へ", class: 'btn btn-accent btn-sm w-24' %>
+        </div>
+      </div>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 変更の概要

* 変更の概要
ラジオボタンのラベルをクリックしたときに、そのラジオボタンが選択されるようにした

* 関連するIssueやプルリクエスト
close #240

## なぜこの変更をするのか
現状はラジオボタンの部分をタップまたはクリックしないと選択できないので、
操作性が悪い。
ラベルをタップまたはクリックしても選択できるようにすると操作性があがるため。

## やったこと
 inputのラジオボタンにidをふり,そのidをlabelのforと合わせる
対象ファイル
- [x] competitions/new, /edit
- [x] squat/new, edit
- [x] benchpress/new, edit
- [x] deadlift/new, edit