### PR TITLE
add: competitionモデルのmodel specを作成

### DIFF
--- a/spec/factories/competitions.rb
+++ b/spec/factories/competitions.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :competition do
+    name {"テスト大会"}
+    venue {"テスト会場"}
+    date { Date.new(2024, 6, 30) }
+    competition_type {"official"}
+    gearcategory_type {"raw"}
+    category {"パワーリフティング"}
+    age_group {"一般"}
+    weight_class {"女子47㎏級"}
+    participation_status {"participated"}
+    association :user
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :user do
+    name { "テストユーザー"}
+    sequence(:email) { |n| "test#{n}@example.com" }
+    password {'12345678'}
+    password_confirmation {'12345678'}
+    role {"user"}
+  end
+end

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Competition, type: :model do
+
+end

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -1,5 +1,60 @@
 require 'rails_helper'
 
 RSpec.describe Competition, type: :model do
+  describe 'バリデーションチェック' do
+    context '全てのフィールドが有効な場合' do
+      it '有効であること' do
+      end
+    end
 
+    context 'ユーザーidが空白のとき' do
+      it '無効であること' do
+      end
+    end
+
+    context '大会名が空白のとき' do
+      it '無効であること' do
+      end
+    end
+
+    context '大会名が225文字以上のとき' do
+      it '無効であること' do
+      end
+    end
+
+    context '施設名が225文字以上のとき' do
+      it '無効であること' do
+      end
+    end
+
+    context '開催日が空白のとき' do
+      it '無効であること' do
+      end
+    end
+
+    context '大会種別が空白のとき' do
+      it '無効であること' do
+      end
+    end
+
+    context 'ギア種別が空白のとき' do
+      it '無効であること' do
+      end
+    end
+
+    context '競技種別が空白のとき' do
+      it '無効であること' do
+      end
+    end
+
+    context '年齢区分が未選択のとき' do
+      it '無効であること' do
+      end
+    end
+
+    context '階級区分が未選択のとき' do
+      it '無効であること' do
+      end
+    end
+  end
 end

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -4,56 +4,83 @@ RSpec.describe Competition, type: :model do
   describe 'バリデーションチェック' do
     context '全てのフィールドが有効な場合' do
       it '有効であること' do
-      end
-    end
-
-    context 'ユーザーidが空白のとき' do
-      it '無効であること' do
+        competition = build(:competition)
+        expect(competition).to be_valid
+        expect(competition.errors).to be_empty
       end
     end
 
     context '大会名が空白のとき' do
       it '無効であること' do
+        competition = build(:competition, name: nil)
+        expect(competition).to be_invalid
+        expect(competition.errors[:name]).to include('を入力してください')
       end
     end
 
     context '大会名が225文字以上のとき' do
       it '無効であること' do
+        competition = build(:competition)
+        competition.name = 'a'*256
+        expect(competition).to be_invalid
+        expect(competition.errors[:name]).to include('は255文字以内で入力してください')
       end
     end
 
     context '施設名が225文字以上のとき' do
       it '無効であること' do
+        competition = build(:competition)
+        competition.venue = 'a'*256
+        expect(competition).to be_invalid
+        expect(competition.errors[:venue]).to include('は255文字以内で入力してください')
       end
     end
 
     context '開催日が空白のとき' do
       it '無効であること' do
+        competition = build(:competition, date: nil)
+        expect(competition).to be_invalid
+        expect(competition.errors[:date]).to include('を入力してください')
       end
     end
 
     context '大会種別が空白のとき' do
       it '無効であること' do
+        competition = build(:competition, competition_type: nil)
+        expect(competition).to be_invalid
+        expect(competition.errors[:competition_type]).to include('を入力してください')
       end
     end
 
     context 'ギア種別が空白のとき' do
       it '無効であること' do
+        competition = build(:competition, gearcategory_type: nil)
+        expect(competition).to be_invalid
+        expect(competition.errors[:gearcategory_type]).to include('を入力してください')
       end
     end
 
     context '競技種別が空白のとき' do
       it '無効であること' do
+        competition = build(:competition, category: nil)
+        expect(competition).to be_invalid
+        expect(competition.errors[:category]).to include('を入力してください')
       end
     end
 
     context '年齢区分が未選択のとき' do
       it '無効であること' do
+        competition = build(:competition, age_group: nil)
+        expect(competition).to be_invalid
+        expect(competition.errors[:age_group]).to include('を入力してください')
       end
     end
 
     context '階級区分が未選択のとき' do
       it '無効であること' do
+        competition = build(:competition, weight_class: nil)
+        expect(competition).to be_invalid
+        expect(competition.errors[:weight_class]).to include('を入力してください')
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,4 +60,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
## 変更の概要

* 変更の概要
competitionモデルのテストのため、model specを書きました

* 関連するIssueやプルリクエスト
close #248 

## なぜこの変更をするのか
* 変更をする理由
Competitionモデルのインスタンスを作成し、
バリデーション処理の成功パターン、失敗パターンについて
正しくバリデーションが機能するか確認するため

## やったこと
### FactoryBotのセットアップ
* [x] `rails_helper.rb`に `FactoryBot::Syntax::Methods`を定義
* [x] Userモデル用のファイル `users.rb`を作成
* [x] Competitionモデル用のファイル `competitions.rb`を作成
* [x] オブジェクト生成のためにそれぞれのファイルにオブジェクトのファクトリを定義
 
### Competitionモデルのバリデーション機能のテストコード作成
* [x] `spec/models/competition_spec.rb` を作成

* [x] 正しいデータの場合、バリデーションエラーが起きないこと

**空白の場合無効であること**
- [x] `date`
- [x]  `competition_type`
- [x]  `gearcategory_type`
- [x] `category`
- [x] `age_group`
- [x]  `weight_class`
- [x] `participation_status`

**255文字以上のとき、無効であること**
- [x] `name` (最大255文字)
- [x]  `venue` (最大255文字)

![image](https://github.com/user-attachments/assets/636395c1-4582-4d1a-aaaf-320c2afdf8fd)
