### PR TITLE
update: 成績グラフのレスポンシブ対応をした

### DIFF
--- a/app/views/charts/index.html.erb
+++ b/app/views/charts/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for :head do %>
     <title>大会結果一覧 | PowerLifter's Log</title>
 <% end %>
-<div class="mx-auto w-full max-w-screen-sm text-center">
-  <div class="mx-auto max-w-80 min-w-80 rounded-lg bg-white shadow my-4 p-2">
-    <h1 class="font-bold text-primary">パワーリフティング(ノーギア)<br/>合計重量</h1>
+<div class="container mx-auto">
+  <div class="mx-auto w-4/5  md:max-w-screen-md rounded-lg bg-white shadow my-4 sm:p-4">
+    <h1 class="font-bold text-primary text-center">パワーリフティング(ノーギア)<br/>合計重量</h1>
       <%= line_chart @classic_power_total_weights,
       xtitle: "開催日" ,
       ytitle: "重量(kg)",
@@ -11,8 +11,8 @@
       empty: "データがありません"
       %>
   </div>
-  <div class="mx-auto max-w-80 min-w-80 rounded-lg bg-white shadow my-4 p-2">
-    <h1 class="font-bold text-primary">パワーリフティング(フルギア)<br/>合計重量</h1>
+  <div class="mx-auto w-4/5  md:max-w-screen-md rounded-lg bg-white shadow my-4 sm:p-4">
+    <h1 class="font-bold text-primary text-center">パワーリフティング(フルギア)<br/>合計重量</h1>
       <%= line_chart @equipped_power_total_weights,
       xtitle: "開催日" ,
       ytitle: "重量(kg)",
@@ -20,8 +20,8 @@
       empty: "データがありません"
       %>
   </div>
-  <div class="mx-auto max-w-80 min-w-80 rounded-lg bg-white shadow my-4 p-2">
-    <h1 class="font-bold text-primary">シングルベンチプレス(ノーギア)<br/>重量</h1>
+  <div class="mx-auto w-4/5  md:max-w-screen-md rounded-lg bg-white shadow my-4 sm:p-4">
+    <h1 class="font-bold text-primary text-center">シングルベンチプレス(ノーギア)<br/>重量</h1>
       <%= line_chart @classic_single_benchpress_weights,
       xtitle: "開催日" ,
       ytitle: "重量(kg)",
@@ -29,8 +29,8 @@
       empty: "データがありません"
       %>
   </div>
-  <div class="mx-auto max-w-80 min-w-80 rounded-lg bg-white shadow my-4 p-2">
-    <h1 class="font-bold text-primary">シングルベンチプレス(フルギア)<br/>重量</h1>
+  <div class="mx-auto w-4/5  md:max-w-screen-md rounded-lg bg-white shadow my-4 sm:p-4">
+    <h1 class="font-bold text-primary text-center">シングルベンチプレス(フルギア)<br/>重量</h1>
       <%= line_chart @equipped_single_benchpress_weights,
       xtitle: "開催日" ,
       ytitle: "重量(kg)",


### PR DESCRIPTION
## 変更の概要

* 変更の概要
成績グラフページのレスポンシブ対応をした

* 関連するIssueやプルリクエスト
close #267

## やったこと
#### レスポンシブ対応
* [x] コンテナクラスを定義して画面のサイズに合わせて、要素の幅を自動的に調整させた
```
<div class="container mx-auto">
・・・
</dev>
```
* [x] 768pxにまでは、成績グラフのカードは画面サイズに合わせて自動的に幅を広げていく
カードの要素に以下のユーティリティを定義
```
w-4/5  md:max-w-screen-md
```
w-4/5: 要素の幅を親要素の80%に設定。画面幅の80%に広がる。
md:max-w-screen-md: 画面幅が768px以上になったら要素の最大幅を固定。

