### PR TITLE
update: 大会詳細ページのレスポンシブ対応

### DIFF
--- a/app/views/competition_records/_competition_record.html.erb
+++ b/app/views/competition_records/_competition_record.html.erb
@@ -1,25 +1,25 @@
-<div class="card-body max-w-72 min-w-72">
+<div class="card-body max-sm:max-w-72 max-sm:min-w-72 sm:w-3/4">
   <div class="flex justify-center">
     <h1 class="card-title text-center">
       試技結果
     </h1>
   </div>
   <div class="border-b-2 border-dashed py-2">
-    <div class="flex items-center justify-between mb-3">
-      <h2 class="font-bold mr-2">検量体重</h2>
+    <div class="flex items-center justify-between sm:justify-start mb-3">
+      <h2 class="font-bold mr-2 sm:text-lg">検量体重</h2>
       <%= link_to edit_competition_weigh_in_path(@competition), class: "flex items-center" do %>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="h-5 w-5" fill="#fda4af" > <!-- アイコンの大きさを設定 -->
           <path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z"/>
         </svg>
       <% end %>
     </div>
-    <p class="text-sm"> <%= competition_record.weight %> kg</p>
+    <p class="text-sm sm:text-base"> <%= competition_record.weight %> kg</p>
   </div>
   <!-- SQ試技結果 -->
   <% unless @competition.category == "シングルベンチプレス" %>
     <div class="border-b-2 border-dashed py-2">
-      <div class="flex items-center justify-between mb-3">
-        <h2 class="font-bold mr-2">スクワット</h2>
+      <div class="flex items-center justify-between sm:justify-start mb-3">
+        <h2 class="font-bold mr-2 sm:text-lg">スクワット</h2>
         <%= link_to edit_competition_squat_path(@competition), class: "flex items-center" do %>
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="h-5 w-5" fill="#fda4af" > <!-- アイコンの大きさを設定 -->
             <path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z"/>
@@ -28,45 +28,45 @@
       </div>
       <!-- SQ第１試技 -->
       <div class="flex flex-row pb-1">
-        <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
-        <p class="text-sm basis-1/3 text-right"> <%= competition_record.squat_first_attempt %> kg</p>
+        <h3 class="font-bold text-sm sm:text-base basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
+        <p class="text-sm sm:text-base basis-1/3 text-right sm:text-center"> <%= competition_record.squat_first_attempt %> kg</p>
         <!-- 判定結果 -->
         <% if competition_record.squat_first_success? %>
-          <p class="text-sm basis-1/3 text-right text-green-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-green-500">
         <% elsif competition_record.squat_first_failure? %>
-          <p class="text-sm basis-1/3 text-right text-red-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-red-500">
         <% elsif competition_record.squat_first_not_attempted? %>
-          <p class="text-sm basis-1/3 text-right text-gray-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-gray-500">
         <% end %>
           <%= competition_record.squat_first_attempt_result_i18n %>
         </p>
       </div>
       <!-- SQ第2試技 -->
       <div class="flex flex-row pb-1">
-        <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.second_attempt') %> </h3>
-        <p class="text-sm basis-1/3 text-right"> <%= competition_record.squat_second_attempt %> kg</p>
+        <h3 class="font-bold text-sm sm:text-base basis-1/3"> <%= t('competition_record.second_attempt') %> </h3>
+        <p class="text-sm sm:text-base basis-1/3 text-right sm:text-center"> <%= competition_record.squat_second_attempt %> kg</p>
         <!-- 判定結果 -->
         <% if competition_record.squat_second_success? %>
-          <p class="text-sm basis-1/3 text-right text-green-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-green-500">
         <% elsif competition_record.squat_second_failure? %>
-          <p class="text-sm basis-1/3 text-right text-red-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-red-500">
         <% elsif competition_record.squat_second_not_attempted? %>
-          <p class="text-sm basis-1/3 text-right text-gray-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-gray-500">
         <% end %>
           <%= competition_record.squat_second_attempt_result_i18n %>
         </p>
       </div>
       <!-- SQ第3試技 -->
       <div class="flex flex-row pb-1">
-        <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.third_attempt') %> </h3>
-        <p class="text-sm basis-1/3 text-right"> <%= competition_record.squat_third_attempt %> kg</p>
+        <h3 class="font-bold text-sm sm:text-base basis-1/3"> <%= t('competition_record.third_attempt') %> </h3>
+        <p class="text-sm sm:text-base basis-1/3 text-right sm:text-center"> <%= competition_record.squat_third_attempt %> kg</p>
         <!-- 判定結果 -->
         <% if competition_record.squat_third_success? %>
-          <p class="text-sm basis-1/3 text-right text-green-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-green-500">
         <% elsif competition_record.squat_third_failure? %>
-          <p class="text-sm basis-1/3 text-right text-red-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-red-500">
         <% elsif competition_record.squat_third_not_attempted? %>
-          <p class="text-sm basis-1/3 text-right text-gray-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-gray-500">
         <% end %>
           <%= competition_record.squat_third_attempt_result_i18n %>
         </p>
@@ -75,8 +75,8 @@
   <% end %>
   <!-- BP試技結果 -->
   <div class="border-b-2 border-dashed py-2">
-    <div class="flex items-center justify-between mb-3">
-      <h2 class="font-bold mr-2">ベンチプレス</h2>
+    <div class="flex items-center justify-between sm:justify-start mb-3">
+      <h2 class="font-bold mr-2 sm:text-lg">ベンチプレス</h2>
       <%= link_to edit_competition_bench_presse_path(@competition), class: "flex items-center" do %>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="h-5 w-5" fill="#fda4af" > <!-- アイコンの大きさを設定 -->
           <path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z"/>
@@ -85,45 +85,45 @@
     </div>
     <!-- BP第１試技 -->
     <div class="flex flex-row pb-1">
-      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
-      <p class="text-sm basis-1/3 text-right"> <%= competition_record.benchpress_first_attempt %> kg</p>
+      <h3 class="font-bold text-sm sm:text-base basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
+      <p class="text-sm sm:text-base basis-1/3 text-right sm:text-center"> <%= competition_record.benchpress_first_attempt %> kg</p>
       <!-- 判定結果 -->
       <% if competition_record.benchpress_first_success? %>
-        <p class="text-sm basis-1/3 text-right text-green-500">
+        <p class="text-sm sm:text-base basis-1/3 text-right text-green-500">
       <% elsif competition_record.benchpress_first_failure? %>
-        <p class="text-sm basis-1/3 text-right text-red-500">
+        <p class="text-sm sm:text-base basis-1/3 text-right text-red-500">
       <% elsif competition_record.benchpress_first_not_attempted? %>
-        <p class="text-sm basis-1/3 text-right text-gray-500">
+        <p class="text-sm sm:text-base basis-1/3 text-right text-gray-500">
       <% end %>
         <%= competition_record.benchpress_first_attempt_result_i18n %>
       </p>
     </div>
     <!-- BP第2試技 -->
     <div class="flex flex-row pb-1">
-      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.second_attempt') %> </h3>
-      <p class="text-sm basis-1/3 text-right"> <%= competition_record.benchpress_second_attempt %> kg</p>
+      <h3 class="font-bold text-sm sm:text-base basis-1/3"> <%= t('competition_record.second_attempt') %> </h3>
+      <p class="text-sm sm:text-base basis-1/3 text-right sm:text-center"> <%= competition_record.benchpress_second_attempt %> kg</p>
       <!-- 判定結果 -->
       <% if competition_record.benchpress_second_success? %>
-        <p class="text-sm basis-1/3 text-right text-green-500">
+        <p class="text-sm sm:text-base basis-1/3 text-right text-green-500">
       <% elsif competition_record.benchpress_second_failure? %>
-        <p class="text-sm basis-1/3 text-right text-red-500">
+        <p class="text-sm sm:text-base basis-1/3 text-right text-red-500">
       <% elsif competition_record.benchpress_second_not_attempted? %>
-        <p class="text-sm basis-1/3 text-right text-gray-500">
+        <p class="text-sm sm:text-base basis-1/3 text-right text-gray-500">
       <% end %>
         <%= competition_record.benchpress_second_attempt_result_i18n %>
       </p>
     </div>
     <!-- BP第3試技 -->
     <div class="flex flex-row pb-1">
-      <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.third_attempt') %> </h3>
-      <p class="text-sm basis-1/3 text-right"> <%= competition_record.benchpress_third_attempt %> kg</p>
+      <h3 class="font-bold text-sm sm:text-base basis-1/3"> <%= t('competition_record.third_attempt') %> </h3>
+      <p class="text-sm sm:text-base basis-1/3 text-right sm:text-center"> <%= competition_record.benchpress_third_attempt %> kg</p>
       <!-- 判定結果 -->
       <% if competition_record.benchpress_third_success? %>
-        <p class="text-sm basis-1/3 text-right text-green-500">
+        <p class="text-sm sm:text-base basis-1/3 text-right text-green-500">
       <% elsif competition_record.benchpress_third_failure? %>
-        <p class="text-sm basis-1/3 text-right text-red-500">
+        <p class="text-sm sm:text-base basis-1/3 text-right text-red-500">
       <% elsif competition_record.benchpress_third_not_attempted? %>
-        <p class="text-sm basis-1/3 text-right text-gray-500">
+        <p class="text-sm sm:text-base basis-1/3 text-right text-gray-500">
       <% end %>
         <%= competition_record.benchpress_third_attempt_result_i18n %>
       </p>
@@ -132,8 +132,8 @@
   <!-- DL試技結果 -->
   <% unless @competition.category == "シングルベンチプレス" %>
     <div class="border-b-2 border-dashed py-2">
-      <div class="flex items-center justify-between mb-3">
-        <h2 class="font-bold mr-2">デッドリフト</h2>
+      <div class="flex items-center justify-between sm:justify-start mb-3">
+        <h2 class="font-bold mr-2 sm:text-lg">デッドリフト</h2>
         <%= link_to edit_competition_deadlift_path(@competition), class: "flex items-center" do %>
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="h-5 w-5" fill="#fda4af" > <!-- アイコンの大きさを設定 -->
             <path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z"/>
@@ -142,45 +142,45 @@
       </div>
       <!-- DL第１試技 -->
       <div class="flex flex-row pb-1">
-        <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
-        <p class="text-sm basis-1/3 text-right"> <%= competition_record.deadlift_first_attempt %> kg</p>
+        <h3 class="font-bold text-sm sm:text-base basis-1/3"> <%= t('competition_record.first_attempt') %> </h3>
+        <p class="text-sm sm:text-base basis-1/3 text-right sm:text-center"> <%= competition_record.deadlift_first_attempt %> kg</p>
         <!-- 判定結果 -->
         <% if competition_record.deadlift_first_success? %>
-          <p class="text-sm basis-1/3 text-right text-green-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-green-500">
         <% elsif competition_record.deadlift_first_failure? %>
-          <p class="text-sm basis-1/3 text-right text-red-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-red-500">
         <% elsif competition_record.deadlift_first_not_attempted? %>
-          <p class="text-sm basis-1/3 text-right text-gray-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-gray-500">
         <% end %>
           <%= competition_record.deadlift_first_attempt_result_i18n %>
         </p>
       </div>
       <!-- DL第2試技 -->
       <div class="flex flex-row pb-1">
-        <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.second_attempt') %> </h3>
-        <p class="text-sm basis-1/3 text-right"> <%= competition_record.deadlift_second_attempt %> kg</p>
+        <h3 class="font-bold text-sm sm:text-base basis-1/3"> <%= t('competition_record.second_attempt') %> </h3>
+        <p class="text-sm sm:text-base basis-1/3 text-right sm:text-center"> <%= competition_record.deadlift_second_attempt %> kg</p>
         <!-- 判定結果 -->
         <% if competition_record.deadlift_second_success? %>
-          <p class="text-sm basis-1/3 text-right text-green-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-green-500">
         <% elsif competition_record.deadlift_second_failure? %>
-          <p class="text-sm basis-1/3 text-right text-red-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-red-500">
         <% elsif competition_record.deadlift_second_not_attempted? %>
-          <p class="text-sm basis-1/3 text-right text-gray-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-gray-500">
         <% end %>
           <%= competition_record.deadlift_second_attempt_result_i18n %>
         </p>
       </div>
       <!-- DLDL第3試技 -->
       <div class="flex flex-row pb-1">
-        <h3 class="font-bold text-sm basis-1/3"> <%= t('competition_record.third_attempt') %> </h3>
-        <p class="text-sm basis-1/3 text-right"> <%= competition_record.deadlift_third_attempt %> kg</p>
+        <h3 class="font-bold text-sm sm:text-base basis-1/3"> <%= t('competition_record.third_attempt') %> </h3>
+        <p class="text-sm sm:text-base basis-1/3 text-right sm:text-center"> <%= competition_record.deadlift_third_attempt %> kg</p>
         <!-- 判定結果 -->
         <% if competition_record.deadlift_third_success? %>
-          <p class="text-sm basis-1/3 text-right text-green-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-green-500">
         <% elsif competition_record.deadlift_third_failure? %>
-          <p class="text-sm basis-1/3 text-right text-red-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-red-500">
         <% elsif competition_record.deadlift_third_not_attempted? %>
-          <p class="text-sm basis-1/3 text-right text-gray-500">
+          <p class="text-sm sm:text-base basis-1/3 text-right text-gray-500">
         <% end %>
           <%= competition_record.deadlift_third_attempt_result_i18n %>
         </p>
@@ -189,8 +189,8 @@
   <% end %>
   <!-- コメント -->
   <div class="border-b-2 border-dashed py-2">
-    <div class="flex items-center justify-between mb-3">
-      <h2 class="font-bold mr-2">コメント</h2>
+    <div class="flex items-center justify-between sm:justify-start mb-3">
+      <h2 class="font-bold mr-2 sm:text-lg">コメント</h2>
       <%= link_to edit_competition_comment_path(@competition), class: "flex items-center" do %>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="h-5 w-5" fill="#fda4af" > <!-- アイコンの大きさを設定 -->
           <path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z"/>

--- a/app/views/competitions/_competition.html.erb
+++ b/app/views/competitions/_competition.html.erb
@@ -1,4 +1,4 @@
-  <div class="mx-auto w-4/5  md:max-w-screen-md rounded-lg bg-white shadow my-4 sm:p-4">
+  <div class="mx-auto w-4/5 md:max-w-screen-md rounded-lg bg-white shadow my-4 sm:p-4">
     <div class="p-4 border-b border-gray-200">
       <div class="flex items-center justify-left">
         <span class="text-sm sm:text-base font-medium text-primary mr-2"><%= competition.competition_type_i18n %></span>

--- a/app/views/competitions/_competition_result.html.erb
+++ b/app/views/competitions/_competition_result.html.erb
@@ -1,77 +1,83 @@
-<div class="card items-center mx-auto max-w-80 min-w-80 bg-white shadow-md p-2">
+<div class="card items-center mx-auto w-4/5 md:max-w-screen-md bg-white shadow-md p-2 my-4">
     <!-- 合計重量とIPF point -->
     <div class="flex flex-row shadow divide-x rounded-lg border-[1px] w-full">
       <!-- 合計重量 -->
       <div class="flex w-1/2 flex-col p-4">
-        <div class="text-sm font-medium text-gray-500">TOTAL</div>
-        <div class="text-2xl font-bold"><%= competition_result.total_lifted_weight %> kg</div>
+        <div class="text-sm sm:text-lg font-medium text-gray-500 sm:text-center">TOTAL</div>
+        <div class="text-2xl sm:text-3xl font-bold sm:text-center"><%= competition_result.total_lifted_weight %> kg</div>
         <!-- 増減バッチ -->
-        <div class="flex flex-col text-sm mt-1">
-          <span class="flex items-center w-4/5 rounded-full px-2 py-1 text-xs font-semibold <%= subtraction_result_color(competition_result.total_subtraction(competition_result, past_competition_result)) %>">
-            <%= raw subtraction_result_allow(competition_result.total_subtraction(competition_result, past_competition_result)) %>
-            <%= competition_result.total_subtraction(competition_result, past_competition_result).abs %> kg
-          </span>
-          <span class= "text-[10px] text-gray-500">(前大会比)</span>
+        <div class="flex flex-col sm:grid sm:justify-items-center text-sm mt-1 sm:mx-auto sm:w-1/2">
+          <p class="flex items-center sm:justify-center w-4/5 rounded-full px-2 py-1 text-xs font-semibold <%= subtraction_result_color(competition_result.total_subtraction(competition_result, past_competition_result)) %>">
+            <span> <%= raw subtraction_result_allow(competition_result.total_subtraction(competition_result, past_competition_result)) %> </span>
+            <span> <%= competition_result.total_subtraction(competition_result, past_competition_result).abs %> kg </span>
+          </p>
+          <span class= "text-[10px] text-gray-500 sm:text-xs">(前大会比)</span>
         </div>
       </div>
       <!-- IPFポイント -->
       <div class="flex w-1/2 flex-col p-4">
-        <div class="text-sm font-medium text-gray-500">IPF POINTS</div>
-        <div class="text-2xl font-bold"><%= competition_result.ipf_points.round(2) %></div>
+        <div class="text-sm sm:text-lg font-medium text-gray-500 sm:text-center">IPF POINTS</div>
+        <div class="text-2xl sm:text-3xl font-bold sm:text-center"><%= competition_result.ipf_points.round(2) %></div>
         <!-- 増減バッチ -->
-        <div class="flex flex-col text-sm mt-1">
-          <span class="flex items-center w-4/5 rounded-full px-2 py-1 text-xs font-semibold <%= subtraction_result_color(competition_result.ipf_points_subtraction(competition_result, past_competition_result)) %>">
-            <%= raw subtraction_result_allow(competition_result.ipf_points_subtraction(competition_result, past_competition_result)) %>
-            <%= competition_result.ipf_points_subtraction(competition_result, past_competition_result).abs %>
-          </span>
-          <span class= "text-[10px] text-gray-500">(前大会比)</span>
+        <div class="flex flex-col sm:grid sm:justify-items-center text-sm mt-1 sm:mx-auto sm:w-1/2">
+          <p class="flex items-center sm:justify-center w-4/5 rounded-full px-2 py-1 text-xs font-semibold <%= subtraction_result_color(competition_result.ipf_points_subtraction(competition_result, past_competition_result)) %>">
+            <span> <%= raw subtraction_result_allow(competition_result.ipf_points_subtraction(competition_result, past_competition_result)) %> </span>
+            <span> <%= competition_result.ipf_points_subtraction(competition_result, past_competition_result).abs %> </span>
+          </p>
+          <span class= "text-[10px] text-gray-500 sm:text-xs">(前大会比)</span>
         </div>
       </div>
     </div>
-      <div class="card-body w-full py-5">
+      <div class="card-body w-full py-5 md:w-3/4">
         <!-- 各種目ベスト重量 -->
         <div class="py-2">
           <div class="flex items-center justify-between mb-3">
-            <h2 class="font-bold mr-2">種目別 最高重量</h2>
-            <span class= "text-[10px] text-gray-500">(前大会比)</span>
+            <h2 class="font-bold mr-2 sm:text-lg">種目別 最高重量</h2>
+            <span class= "text-[10px] text-gray-500 sm:text-xs">(前大会比)</span>
           </div>
           <!-- スクワット -->
           <% if competition.category == "パワーリフティング" %>
             <div class="flex flex-row pb-1 items-center">
-              <h3 class="font-bold text-sm basis-1/3 ">BEST SQ</h3>
-              <p class="text-sm basis-1/3 text-right pr-2"><%= competition_result.best_squat_weight %>kg</p>
+              <h3 class="font-bold text-sm basis-1/3 sm:text-lg">BEST SQ</h3>
+              <p class="text-sm basis-1/3 text-right sm:text-center pr-2 sm:text-lg sm:font-bold"><%= competition_result.best_squat_weight %>kg</p>
               <!-- 前回からの伸び -->
-              <div class="text-sm basis-1/3 ">
-                <span class="flex w-full place-items-center rounded-full px-2 py-1 text-xs font-semibold <%= subtraction_result_color(competition_result.squat_subtraction(competition_result, past_competition_result)) %>">
-                  <%= raw subtraction_result_allow(competition_result.squat_subtraction(competition_result, past_competition_result)) %>
-                  <%= competition_result.squat_subtraction(competition_result, past_competition_result).abs %>kg
-                </span>
+              <div class="text-sm basis-1/3 sm:grid sm:justify-items-end">
+                <div class="sm:w-1/2">
+                  <p class="flex w-full place-items-center sm:justify-center rounded-full px-2 py-1 text-xs font-semibold <%= subtraction_result_color(competition_result.squat_subtraction(competition_result, past_competition_result)) %>">
+                    <span> <%= raw subtraction_result_allow(competition_result.squat_subtraction(competition_result, past_competition_result)) %> </span>
+                    <span> <%= competition_result.squat_subtraction(competition_result, past_competition_result).abs %>kg </span>
+                  </p>
+                </div>
               </div>
             </div>
           <% end %>
           <!-- ベンチプレス -->
           <div class="flex flex-row pb-1 items-center">
-            <h3 class="font-bold text-sm basis-1/3 ">BEST BP</h3>
-            <p class="text-sm basis-1/3 text-right pr-2 "><%= competition_result.best_benchpress_weight %>kg</p>
+            <h3 class="font-bold text-sm basis-1/3 sm:text-lg">BEST BP</h3>
+            <p class="text-sm basis-1/3 text-right sm:text-center pr-2 sm:text-lg sm:font-bold"><%= competition_result.best_benchpress_weight %>kg</p>
             <!-- 前回からの伸び -->
-            <div class="text-sm basis-1/3 ">
-              <span class="flex w-full place-items-center rounded-full px-2 py-1 text-xs font-semibold <%= subtraction_result_color(competition_result.benchpress_subtraction(competition_result, past_competition_result)) %>">
-                <%= raw subtraction_result_allow(competition_result.benchpress_subtraction(competition_result, past_competition_result)) %>
-                <%= competition_result.benchpress_subtraction(competition_result, past_competition_result).abs %>kg
-              </span>
+            <div class="text-sm basis-1/3 sm:grid sm:justify-items-end">
+              <div class="sm:w-1/2">
+                <p class="flex w-full place-items-center sm:justify-center rounded-full px-2 py-1 text-xs font-semibold <%= subtraction_result_color(competition_result.benchpress_subtraction(competition_result, past_competition_result)) %>">
+                  <span> <%= raw subtraction_result_allow(competition_result.benchpress_subtraction(competition_result, past_competition_result)) %> </span>
+                  <span> <%= competition_result.benchpress_subtraction(competition_result, past_competition_result).abs %>kg </span>
+                </p>
+              </div>
             </div>
           </div>
           <!-- デッドリフト -->
           <% if competition.category == "パワーリフティング" %>
             <div class="flex flex-row pb-1 items-center">
-              <h3 class="font-bold text-sm basis-1/3 ">BEST DL</h3>
-              <p class="text-sm basis-1/3 text-right pr-2 "><%= competition_result.best_deadlift_weight %>kg</p>
+              <h3 class="font-bold text-sm basis-1/3 sm:text-lg">BEST DL</h3>
+              <p class="text-sm basis-1/3 text-right sm:text-center pr-2 sm:text-lg sm:font-bold"><%= competition_result.best_deadlift_weight %>kg</p>
               <!-- 前回からの伸び -->
-              <div class="text-sm basis-1/3 ">
-                <span class="flex w-full place-items-center rounded-full px-2 py-1 text-xs font-semibold <%= subtraction_result_color(competition_result.deadlift_subtraction(competition_result, past_competition_result)) %>">
-                  <%= raw subtraction_result_allow(competition_result.deadlift_subtraction(competition_result, past_competition_result)) %>
-                  <%= competition_result.deadlift_subtraction(competition_result, past_competition_result).abs %>kg
-                </span>
+              <div class="text-sm basis-1/3 sm:grid sm:justify-items-end">
+                <div class="sm:w-1/2">
+                  <p class="flex w-full place-items-center sm:justify-center rounded-full px-2 py-1 text-xs font-semibold <%= subtraction_result_color(competition_result.deadlift_subtraction(competition_result, past_competition_result)) %>">
+                    <span> <%= raw subtraction_result_allow(competition_result.deadlift_subtraction(competition_result, past_competition_result)) %> </span>
+                    <span> <%= competition_result.deadlift_subtraction(competition_result, past_competition_result).abs %>kg </span>
+                  </p>
+                </div>
               </div>
             </div>
           <% end %>

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 <div class="container mx-auto">
   <div class="card items-center mx-auto w-4/5 md:max-w-screen-md bg-white shadow-md p-4 my-4">
-    <div class="card-body">
+    <div class="card-body max-sm:max-w-72 max-sm:min-w-72 sm:w-3/4">
       <div class="flex justify-center">
         <h1 class="card-title text-center">
           <%= @competition.name %>
@@ -15,27 +15,27 @@
       </div>
       <div class="sm:flex sm:justify-start sm:items-center border-b-2 border-dashed py-2">
         <h2 class="font-bold sm:mr-5"><%= Competition.human_attribute_name(:date) %>:</h2>
-        <p class="text-sm"> <%= @competition.date %> </p>
+        <p class="text-sm sm:text-base"> <%= @competition.date %> </p>
       </div>
       <div class="sm:flex sm:justify-start sm:items-center border-b-2 border-dashed py-2">
         <h2 class="font-bold sm:mr-5"><%= Competition.human_attribute_name(:competition_type) %>:</h2>
-        <p class="text-sm"> <%= @competition.competition_type_i18n %> </p>
+        <p class="text-sm sm:text-base"> <%= @competition.competition_type_i18n %> </p>
       </div>
       <div class="sm:flex sm:justify-start sm:items-center border-b-2 border-dashed py-2">
         <h2 class="font-bold sm:mr-5"><%= Competition.human_attribute_name(:gearcategory_type) %>:</h2>
-        <p class="text-sm"> <%= @competition.gearcategory_type_i18n %> </p>
+        <p class="text-sm sm:text-base"> <%= @competition.gearcategory_type_i18n %> </p>
       </div>
       <div class="sm:flex sm:justify-start sm:items-center border-b-2 border-dashed py-2">
         <h2 class="font-bold sm:mr-5"><%= Competition.human_attribute_name(:category) %>:</h2>
-        <p class="text-sm"> <%= @competition.category %> </p>
+        <p class="text-sm sm:text-base"> <%= @competition.category %> </p>
       </div>
       <div class="sm:flex sm:justify-start sm:items-center border-b-2 border-dashed py-2">
         <h2 class="font-bold sm:mr-5"><%= Competition.human_attribute_name(:age_group) %>:</h2>
-        <p class="text-sm"> <%= @competition.age_group %> </p>
+        <p class="text-sm sm:text-base"> <%= @competition.age_group %> </p>
       </div>
       <div class="sm:flex sm:justify-start sm:items-center border-b-2 border-dashed py-2">
         <h2 class="font-bold sm:mr-5"><%= Competition.human_attribute_name(:weight_class) %>:</h2>
-        <p class="text-sm"> <%= @competition.weight_class %> </p>
+        <p class="text-sm sm:text-base"> <%= @competition.weight_class %> </p>
       </div>
       <div class="grid grid-cols-3 items-center w-full">
         <div></div>
@@ -56,7 +56,7 @@
     <%= render 'competition_result', competition: @competition, competition_result: @competition_result, past_competition_result: @past_competition_result, past_competition: @past_competition %>
   <% end %>
   <!-- 大会試技結果詳細情報 -->
-  <div class="card items-center mx-auto max-w-80 min-w-80 bg-white shadow-xl p-4">
+  <div class="card items-center mx-auto w-4/5 md:max-w-screen-md bg-white shadow-md p-4 my-4">
     <% if CompetitionRecord.exists?(competition_id: @competition.id) %>
       <%= render 'competition_records/competition_record', competition_record: @competition_record, competition: @competition%>
     <% else %>

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -1,71 +1,69 @@
 <% content_for :head do %>
     <title><%= @competition.name %> | PowerLifter's Log</title>
 <% end %>
-<div class="hero min-h-screen">
-  <div class="hero-content flex-col">
-    <div class="card items-center mx-auto max-w-80 min-w-80 bg-white shadow-md p-4">
-      <div class="card-body max-w-72 min-w-72">
+<div class="container mx-auto">
+  <div class="card items-center mx-auto w-4/5 md:max-w-screen-md bg-white shadow-md p-4 my-4">
+    <div class="card-body">
+      <div class="flex justify-center">
+        <h1 class="card-title text-center">
+          <%= @competition.name %>
+        </h1>
+      </div>
+      <div class="sm:flex sm:justify-start sm:items-center border-b-2 border-dashed py-2">
+        <h2 class="font-bold sm:mr-5"><%= Competition.human_attribute_name(:venue) %>:</h2>
+        <p class="text-sm sm:text-base"> <%= @competition.venue %></p>
+      </div>
+      <div class="sm:flex sm:justify-start sm:items-center border-b-2 border-dashed py-2">
+        <h2 class="font-bold sm:mr-5"><%= Competition.human_attribute_name(:date) %>:</h2>
+        <p class="text-sm"> <%= @competition.date %> </p>
+      </div>
+      <div class="sm:flex sm:justify-start sm:items-center border-b-2 border-dashed py-2">
+        <h2 class="font-bold sm:mr-5"><%= Competition.human_attribute_name(:competition_type) %>:</h2>
+        <p class="text-sm"> <%= @competition.competition_type_i18n %> </p>
+      </div>
+      <div class="sm:flex sm:justify-start sm:items-center border-b-2 border-dashed py-2">
+        <h2 class="font-bold sm:mr-5"><%= Competition.human_attribute_name(:gearcategory_type) %>:</h2>
+        <p class="text-sm"> <%= @competition.gearcategory_type_i18n %> </p>
+      </div>
+      <div class="sm:flex sm:justify-start sm:items-center border-b-2 border-dashed py-2">
+        <h2 class="font-bold sm:mr-5"><%= Competition.human_attribute_name(:category) %>:</h2>
+        <p class="text-sm"> <%= @competition.category %> </p>
+      </div>
+      <div class="sm:flex sm:justify-start sm:items-center border-b-2 border-dashed py-2">
+        <h2 class="font-bold sm:mr-5"><%= Competition.human_attribute_name(:age_group) %>:</h2>
+        <p class="text-sm"> <%= @competition.age_group %> </p>
+      </div>
+      <div class="sm:flex sm:justify-start sm:items-center border-b-2 border-dashed py-2">
+        <h2 class="font-bold sm:mr-5"><%= Competition.human_attribute_name(:weight_class) %>:</h2>
+        <p class="text-sm"> <%= @competition.weight_class %> </p>
+      </div>
+      <div class="grid grid-cols-3 items-center w-full">
+        <div></div>
         <div class="flex justify-center">
-          <h1 class="card-title text-center">
-            <%= @competition.name %>
-          </h1>
+          <%= link_to "編集", edit_competition_path(@competition), class: "btn btn-xs sm:btn-sm md:btn-md btn-outline btn-accent max-w-24 mx-2" %>
         </div>
-        <div class="border-b-2 border-dashed py-2">
-          <h2 class="font-bold"><%= Competition.human_attribute_name(:venue) %>:</h2>
-          <p class="text-sm"> <%= @competition.venue %></p>
-        </div>
-        <div class="border-b-2 border-dashed py-2">
-          <h2 class="font-bold"><%= Competition.human_attribute_name(:date) %>:</h2>
-          <p class="text-sm"> <%= @competition.date %> </p>
-        </div>
-        <div class="border-b-2 border-dashed py-2">
-          <h2 class="font-bold"><%= Competition.human_attribute_name(:competition_type) %>:</h2>
-          <p class="text-sm"> <%= @competition.competition_type_i18n %> </p>
-        </div>
-        <div class="border-b-2 border-dashed py-2">
-          <h2 class="font-bold"><%= Competition.human_attribute_name(:gearcategory_type) %>:</h2>
-          <p class="text-sm"> <%= @competition.gearcategory_type_i18n %> </p>
-        </div>
-        <div class="border-b-2 border-dashed py-2">
-          <h2 class="font-bold"><%= Competition.human_attribute_name(:category) %>:</h2>
-          <p class="text-sm"> <%= @competition.category %> </p>
-        </div>
-        <div class="border-b-2 border-dashed py-2">
-          <h2 class="font-bold"><%= Competition.human_attribute_name(:age_group) %>:</h2>
-          <p class="text-sm"> <%= @competition.age_group %> </p>
-        </div>
-        <div class="border-b-2 border-dashed py-2">
-          <h2 class="font-bold"><%= Competition.human_attribute_name(:weight_class) %>:</h2>
-          <p class="text-sm"> <%= @competition.weight_class %> </p>
-        </div>
-        <div class="grid grid-cols-3 items-center w-full">
-          <div></div>
-          <div class="flex justify-center">
-            <%= link_to "編集", edit_competition_path(@competition), class: "btn btn-sm btn-outline btn-accent max-w-24 mx-2" %>
-          </div>
-          <div class="flex justify-end">
-            <%= link_to competition_path(@competition), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" }, class: "link text-[#ef4444] max-w-24 flex items-center" do %>
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="w-4 h-4 hover:text-white"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="#ef4444" d="M170.5 51.6L151.5 80h145l-19-28.4c-1.5-2.2-4-3.6-6.7-3.6H177.1c-2.7 0-5.2 1.3-6.7 3.6zm147-26.6L354.2 80H368h48 8c13.3 0 24 10.7 24 24s-10.7 24-24 24h-8V432c0 44.2-35.8 80-80 80H112c-44.2 0-80-35.8-80-80V128H24c-13.3 0-24-10.7-24-24S10.7 80 24 80h8H80 93.8l36.7-55.1C140.9 9.4 158.4 0 177.1 0h93.7c18.7 0 36.2 9.4 46.6 24.9zM80 128V432c0 17.7 14.3 32 32 32H336c17.7 0 32-14.3 32-32V128H80zm80 64V400c0 8.8-7.2 16-16 16s-16-7.2-16-16V192c0-8.8 7.2-16 16-16s16 7.2 16 16zm80 0V400c0 8.8-7.2 16-16 16s-16-7.2-16-16V192c0-8.8 7.2-16 16-16s16 7.2 16 16z"/></svg>
-              削除
-            <% end %>
-          </div>
+        <div class="flex justify-end">
+          <%= link_to competition_path(@competition), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" }, class: "link text-[#ef4444] max-w-24 flex items-center" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="w-4 h-4 hover:text-white"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="#ef4444" d="M170.5 51.6L151.5 80h145l-19-28.4c-1.5-2.2-4-3.6-6.7-3.6H177.1c-2.7 0-5.2 1.3-6.7 3.6zm147-26.6L354.2 80H368h48 8c13.3 0 24 10.7 24 24s-10.7 24-24 24h-8V432c0 44.2-35.8 80-80 80H112c-44.2 0-80-35.8-80-80V128H24c-13.3 0-24-10.7-24-24S10.7 80 24 80h8H80 93.8l36.7-55.1C140.9 9.4 158.4 0 177.1 0h93.7c18.7 0 36.2 9.4 46.6 24.9zM80 128V432c0 17.7 14.3 32 32 32H336c17.7 0 32-14.3 32-32V128H80zm80 64V400c0 8.8-7.2 16-16 16s-16-7.2-16-16V192c0-8.8 7.2-16 16-16s16 7.2 16 16zm80 0V400c0 8.8-7.2 16-16 16s-16-7.2-16-16V192c0-8.8 7.2-16 16-16s16 7.2 16 16z"/></svg>
+            削除
+          <% end %>
         </div>
       </div>
     </div>
-        <!-- 合計重量・各種目最高重量 -->
-    <% if @competition_result.present? %>
-      <%= render 'competition_result', competition: @competition, competition_result: @competition_result, past_competition_result: @past_competition_result, past_competition: @past_competition %>
+  </div>
+      <!-- 合計重量・各種目最高重量 -->
+  <% if @competition_result.present? %>
+    <%= render 'competition_result', competition: @competition, competition_result: @competition_result, past_competition_result: @past_competition_result, past_competition: @past_competition %>
+  <% end %>
+  <!-- 大会試技結果詳細情報 -->
+  <div class="card items-center mx-auto max-w-80 min-w-80 bg-white shadow-xl p-4">
+    <% if CompetitionRecord.exists?(competition_id: @competition.id) %>
+      <%= render 'competition_records/competition_record', competition_record: @competition_record, competition: @competition%>
+    <% else %>
+      <div class="flex-col flex justify-center items-center w-full">
+        <p>大会結果記録はまだ未登録です</p>
+        <%= link_to "大会結果記録", new_competition_weigh_in_path(@competition), class: "btn btn-sm btn-accent" %>
+      </div>
     <% end %>
-    <!-- 大会試技結果詳細情報 -->
-    <div class="card items-center mx-auto max-w-80 min-w-80 bg-white shadow-xl p-4">
-      <% if CompetitionRecord.exists?(competition_id: @competition.id) %>
-        <%= render 'competition_records/competition_record', competition_record: @competition_record, competition: @competition%>
-      <% else %>
-        <div class="flex-col flex justify-center items-center w-full">
-          <p>大会結果記録はまだ未登録です</p>
-          <%= link_to "大会結果記録", new_competition_weigh_in_path(@competition), class: "btn btn-sm btn-accent" %>
-        </div>
-      <% end %>
-    </div>
   </div>
 </div>


### PR DESCRIPTION
## 変更の概要

* 変更の概要
大会詳細ページのレスポンシブ対応をした

* 関連するIssueやプルリクエスト
close #265 

## やったこと
#### レスポンシブ対応
* [x] コンテナクラスを定義して画面のサイズに合わせて、要素の幅を自動的に調整させた
```
<div class="container mx-auto">
・・・
</dev>
```
* [x] 768pxにまでは、大会情報部、試技計算結果、試技結果部のそれぞれのカードの幅を画面サイズに合わせて自動的に幅を広げていく
カードの要素に以下のユーティリティを定義
```
w-4/5  md:max-w-screen-md
```
w-4/5: 要素の幅を親要素の80%に設定。画面幅の80%に広がる。
md:max-w-screen-md: 画面幅が768px以上になったら要素の最大幅を固定。

- [x] 640px以上から文字の位置と大きさを調整

