### PR TITLE
add: 1024px以上でボトムナビゲーションを非表示にしてサイドバーを表示する

### DIFF
--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,6 +1,4 @@
 class TopsController < ApplicationController
   skip_before_action :require_login
-  def index
-    @users = User.all
-  end
+  def index; end
 end

--- a/app/views/competitions/index.html.erb
+++ b/app/views/competitions/index.html.erb
@@ -3,6 +3,6 @@
 <% end %>
 <div class="container mx-auto">
     <!-- 大会結果一覧 -->
-  <h1 class="text-2xl text-center">出場済大会の一覧</h1>
+  <h1 class="text-2xl text-center mt-5">出場済大会の一覧</h1>
   <%= render @competitions %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,11 +32,29 @@
     <% end %>
     <!-- ヘッダー -->
     <div class="py-16">
-      <% if current_user&.guest? %>
-        <%= render "shared/login_prompt" %>
-      <% end %>
-      <%= render "shared/flash_message" %>
-      <%= yield %>
+      <!-- サイドバー -->
+      <div class="drawer lg:drawer-open">
+        <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
+        <div class="drawer-content flex flex-col items-center justify-center">
+          <!-- Page content here -->
+          <% if current_user&.guest? %>
+            <%= render "shared/login_prompt" %>
+          <% end %>
+          <%= render "shared/flash_message" %>
+          <%= yield %>
+        </div>
+        <% if logged_in? %>
+          <div class="drawer-side">
+            <label for="my-drawer-2" aria-label="close sidebar" class="drawer-overlay"></label>
+            <ul class="menu bg-base-200 text-base-content min-h-full w-80 p-4">
+              <!-- Sidebar content here -->
+              <li><a>Sidebar Item 1</a></li>
+              <li><a>Sidebar Item 2</a></li>
+            </ul>
+          </div>
+        <% end %>
+      </div>
+      <!-- サイドバー -->
     </div>
     <!-- フッターとボトムナビゲーション -->
     <% if logged_in? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,13 +44,13 @@
           <%= yield %>
         </div>
         <% if logged_in? %>
-          <div class="drawer-side">
+          <div class="drawer-side h-screen">
             <label for="my-drawer-2" aria-label="close sidebar" class="drawer-overlay"></label>
-            <ul class="menu bg-base-200 text-base-content min-h-full w-80 p-4">
+            <ul class="menu bg-primary text-primary-content w-80 rounded-lg p-4">
               <!-- Sidebar content here -->
               <li class="my-2">
                 <%= link_to competitions_path do %>
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="#fc345c" viewBox="0 0 576 512">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="#eafff7" viewBox="0 0 576 512">
                     <path d="M575.8 255.5c0 18-15 32.1-32 32.1l-32 0 .7 160.2c0 2.7-.2 5.4-.5 8.1l0 16.2c0 22.1-17.9 40-40 40l-16 0c-1.1 0-2.2 0-3.3-.1c-1.4 .1-2.8 .1-4.2 .1L416 512l-24 0c-22.1 0-40-17.9-40-40l0-24 0-64c0-17.7-14.3-32-32-32l-64 0c-17.7 0-32 14.3-32 32l0 64 0 24c0 22.1-17.9 40-40 40l-24 0-31.9 0c-1.5 0-3-.1-4.5-.2c-1.2 .1-2.4 .2-3.6 .2l-16 0c-22.1 0-40-17.9-40-40l0-112c0-.9 0-1.9 .1-2.8l0-69.7-32 0c-18 0-32-14-32-32.1c0-9 3-17 10-24L266.4 8c7-7 15-8 22-8s15 2 21 7L564.8 231.5c8 7 12 15 11 24z"/>
                   </svg>
                   <span class="btm-nav-label text-lg"><%= t('bottom_navi.home') %></span>
@@ -58,7 +58,7 @@
               </li>
               <li class="my-2">
                 <%= link_to new_competition_path do %>
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="#fc345c" class="bi bi-pencil-square" viewBox="0 0 16 16">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="#eafff7" class="bi bi-pencil-square" viewBox="0 0 16 16">
                     <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.646a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z"/>
                     <path fill-rule="evenodd" d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5v11z"/>
                   </svg>
@@ -67,7 +67,7 @@
               </li>
               <li class="my-2">
                 <%= link_to charts_path do %>
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="#fafafa" viewBox="0 0 24 24" stroke="#fc345c">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="#fc345c" viewBox="0 0 24 24" stroke="#eafff7">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
                   </svg>
                   <span class="btm-nav-label text-lg"><%= t('bottom_navi.statics') %></span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,8 +48,31 @@
             <label for="my-drawer-2" aria-label="close sidebar" class="drawer-overlay"></label>
             <ul class="menu bg-base-200 text-base-content min-h-full w-80 p-4">
               <!-- Sidebar content here -->
-              <li><a>Sidebar Item 1</a></li>
-              <li><a>Sidebar Item 2</a></li>
+              <li class="my-2">
+                <%= link_to competitions_path do %>
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="#fc345c" viewBox="0 0 576 512">
+                    <path d="M575.8 255.5c0 18-15 32.1-32 32.1l-32 0 .7 160.2c0 2.7-.2 5.4-.5 8.1l0 16.2c0 22.1-17.9 40-40 40l-16 0c-1.1 0-2.2 0-3.3-.1c-1.4 .1-2.8 .1-4.2 .1L416 512l-24 0c-22.1 0-40-17.9-40-40l0-24 0-64c0-17.7-14.3-32-32-32l-64 0c-17.7 0-32 14.3-32 32l0 64 0 24c0 22.1-17.9 40-40 40l-24 0-31.9 0c-1.5 0-3-.1-4.5-.2c-1.2 .1-2.4 .2-3.6 .2l-16 0c-22.1 0-40-17.9-40-40l0-112c0-.9 0-1.9 .1-2.8l0-69.7-32 0c-18 0-32-14-32-32.1c0-9 3-17 10-24L266.4 8c7-7 15-8 22-8s15 2 21 7L564.8 231.5c8 7 12 15 11 24z"/>
+                  </svg>
+                  <span class="btm-nav-label text-lg"><%= t('bottom_navi.home') %></span>
+                <% end %>
+              </li>
+              <li class="my-2">
+                <%= link_to new_competition_path do %>
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="#fc345c" class="bi bi-pencil-square" viewBox="0 0 16 16">
+                    <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.646a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z"/>
+                    <path fill-rule="evenodd" d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5v11z"/>
+                  </svg>
+                  <span class="btm-nav-label text-lg"><%= t('bottom_navi.create') %></span>
+                <% end %>
+              </li>
+              <li class="my-2">
+                <%= link_to charts_path do %>
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="#fafafa" viewBox="0 0 24 24" stroke="#fc345c">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                  </svg>
+                  <span class="btm-nav-label text-lg"><%= t('bottom_navi.statics') %></span>
+                <% end %>
+              </li>
             </ul>
           </div>
         <% end %>

--- a/app/views/shared/_bottom_navbar.html.erb
+++ b/app/views/shared/_bottom_navbar.html.erb
@@ -1,10 +1,11 @@
-<div class="btm-nav">
+<div class="btm-nav lg:hidden">
   <%= link_to competitions_path do %>
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="#fc345c" viewBox="0 0 24 24" stroke="#fc345c"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" /></svg>
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="#fc345c" viewBox="0 0 24 24" stroke="#fc345c">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+    </svg>
     <span class="btm-nav-label"><%= t('bottom_navi.home') %></span>
-  </button>
   <% end %>
-  <%= link_to new_competition_path, class:"active" do %>
+  <%= link_to new_competition_path do %>
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#fc345c" class="bi bi-pencil-square" viewBox="0 0 16 16">
       <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.646a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z"/>
       <path fill-rule="evenodd" d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5v11z"/>
@@ -12,7 +13,9 @@
     <span class="btm-nav-label"><%= t('bottom_navi.create') %></span>
   <% end %>
   <%= link_to charts_path do %>
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="#fafafa" viewBox="0 0 24 24" stroke="#fc345c"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="#fafafa" viewBox="0 0 24 24" stroke="#fc345c">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+    </svg>
     <span class="btm-nav-label"><%= t('bottom_navi.statics') %></span>
   <% end %>
 </div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |message_type, message| %>
-  <div class="rounded-md p-4 text-sm <%= flash_background_color(message_type) %> ">
+  <div role="alert" class="alert mt-2 rounded-md p-4 text-sm <%= flash_background_color(message_type) %> ">
     <%= message %>
   </div>
 <% end %>


### PR DESCRIPTION
## 変更の概要
* 変更の概要
1024px以上でボトムナビゲーションを非表示にしてサイドバーを表示する

* 関連するIssueやプルリクエスト
close #308


## なぜこの変更をするのか

* 変更をする理由
1024px以上の画面サイズになると、ボトムナビでは操作性がわるい
ボトムナビは非表示にしてサイドバーを設ける


## やったこと

* [x] [daisyUIのサイドバーのコンポーネント](https://daisyui.com/components/drawer/#:~:text=Sidebar%20Item%202-,%23%20%E3%83%AC%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B7%E3%83%96,-Sidebar%20is%20always)を使用
 * [x] フラッシュメッセージの横幅が小さくなりすぎないように、daisyUIのalertのコンポーネントに変更した
