### PR TITLE
add: プライバシーポリシーと利用規約のレスポンシブ対応

### DIFF
--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,8 +1,8 @@
 <% content_for :head do %>
     <title>プライバシーポリシー | PowerLifter's Log</title>
 <% end %>
-<div class="bg-base-200 py-8">
-  <div class="mx-auto max-w-80 min-w-80 rounded-lg text-left pb-16 bg-white">
+<div class="container mx-auto">
+  <div class="mx-auto w-4/5 md:max-w-screen-md rounded-lg shadow text-left pb-16 bg-white">
     <h1 class="text-center py-8 text-2xl font-bold">プライバシーポリシー</h1>
     <div class="px-4 pb-4">
       <h2 class="text-xl font-bold text-left py-8">お客様から取得する情報</h2>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,8 +1,8 @@
 <% content_for :head do %>
     <title>利用規約 | PowerLifter's Log</title>
 <% end %>
-<div class="bg-base-200">
-  <div class="mx-auto max-w-80 min-w-80 rounded-lg text-left bg-white">
+<div class="container mx-auto">
+  <div class="mx-auto w-4/5 md:max-w-screen-md rounded-lg shadow text-left pb-16 bg-white">
     <h1 class="text-center py-8 text-4xl font-bold">利用規約</h1>
     <div class="px-4 pb-4">
       <p>この利用規約（以下，「本規約」といいます。）は、PowerLifter's Log（以下，「当方」といいます。）がこのウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。<br>


### PR DESCRIPTION
## 変更の概要

* 変更の概要
利用規約とプライバシーポリシーページのレスポンシブ対応をした

* 関連するIssueやプルリクエスト
close #313

## やったこと
#### レスポンシブ対応
* [x] コンテナクラスを定義して画面のサイズに合わせて、要素の幅を自動的に調整させた
```
<div class="container mx-auto">
・・・
</dev>
```
* [x] 768pxにまでは、カードは画面サイズに合わせて自動的に幅を広げていく
カードの要素に以下のユーティリティを定義
```
w-4/5  md:max-w-screen-md
```
w-4/5: 要素の幅を親要素の80%に設定。画面幅の80%に広がる。
md:max-w-screen-md: 画面幅が768px以上になったら要素の最大幅を固定。
 
