### PR TITLE
add: プロフィールの新規登録と編集ページのレスポンシブ対応

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,37 +44,39 @@
           <%= yield %>
         </div>
         <% if logged_in? %>
-          <div class="drawer-side h-screen">
-            <label for="my-drawer-2" aria-label="close sidebar" class="drawer-overlay"></label>
-            <ul class="menu bg-primary text-primary-content w-80 rounded-lg p-4">
-              <!-- Sidebar content here -->
-              <li class="my-2">
-                <%= link_to competitions_path do %>
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="#eafff7" viewBox="0 0 576 512">
-                    <path d="M575.8 255.5c0 18-15 32.1-32 32.1l-32 0 .7 160.2c0 2.7-.2 5.4-.5 8.1l0 16.2c0 22.1-17.9 40-40 40l-16 0c-1.1 0-2.2 0-3.3-.1c-1.4 .1-2.8 .1-4.2 .1L416 512l-24 0c-22.1 0-40-17.9-40-40l0-24 0-64c0-17.7-14.3-32-32-32l-64 0c-17.7 0-32 14.3-32 32l0 64 0 24c0 22.1-17.9 40-40 40l-24 0-31.9 0c-1.5 0-3-.1-4.5-.2c-1.2 .1-2.4 .2-3.6 .2l-16 0c-22.1 0-40-17.9-40-40l0-112c0-.9 0-1.9 .1-2.8l0-69.7-32 0c-18 0-32-14-32-32.1c0-9 3-17 10-24L266.4 8c7-7 15-8 22-8s15 2 21 7L564.8 231.5c8 7 12 15 11 24z"/>
-                  </svg>
-                  <span class="btm-nav-label text-lg"><%= t('bottom_navi.home') %></span>
-                <% end %>
-              </li>
-              <li class="my-2">
-                <%= link_to new_competition_path do %>
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="#eafff7" class="bi bi-pencil-square" viewBox="0 0 16 16">
-                    <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.646a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z"/>
-                    <path fill-rule="evenodd" d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5v11z"/>
-                  </svg>
-                  <span class="btm-nav-label text-lg"><%= t('bottom_navi.create') %></span>
-                <% end %>
-              </li>
-              <li class="my-2">
-                <%= link_to charts_path do %>
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="#fc345c" viewBox="0 0 24 24" stroke="#eafff7">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                  </svg>
-                  <span class="btm-nav-label text-lg"><%= t('bottom_navi.statics') %></span>
-                <% end %>
-              </li>
-            </ul>
-          </div>
+          <% if @show_header_nav %>
+            <div class="drawer-side h-screen">
+              <label for="my-drawer-2" aria-label="close sidebar" class="drawer-overlay"></label>
+              <ul class="menu bg-primary text-primary-content w-80 rounded-lg p-4">
+                <!-- Sidebar content here -->
+                <li class="my-2">
+                  <%= link_to competitions_path do %>
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="#eafff7" viewBox="0 0 576 512">
+                      <path d="M575.8 255.5c0 18-15 32.1-32 32.1l-32 0 .7 160.2c0 2.7-.2 5.4-.5 8.1l0 16.2c0 22.1-17.9 40-40 40l-16 0c-1.1 0-2.2 0-3.3-.1c-1.4 .1-2.8 .1-4.2 .1L416 512l-24 0c-22.1 0-40-17.9-40-40l0-24 0-64c0-17.7-14.3-32-32-32l-64 0c-17.7 0-32 14.3-32 32l0 64 0 24c0 22.1-17.9 40-40 40l-24 0-31.9 0c-1.5 0-3-.1-4.5-.2c-1.2 .1-2.4 .2-3.6 .2l-16 0c-22.1 0-40-17.9-40-40l0-112c0-.9 0-1.9 .1-2.8l0-69.7-32 0c-18 0-32-14-32-32.1c0-9 3-17 10-24L266.4 8c7-7 15-8 22-8s15 2 21 7L564.8 231.5c8 7 12 15 11 24z"/>
+                    </svg>
+                    <span class="btm-nav-label text-lg"><%= t('bottom_navi.home') %></span>
+                  <% end %>
+                </li>
+                <li class="my-2">
+                  <%= link_to new_competition_path do %>
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="#eafff7" class="bi bi-pencil-square" viewBox="0 0 16 16">
+                      <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.646a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z"/>
+                      <path fill-rule="evenodd" d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5v11z"/>
+                    </svg>
+                    <span class="btm-nav-label text-lg"><%= t('bottom_navi.create') %></span>
+                  <% end %>
+                </li>
+                <li class="my-2">
+                  <%= link_to charts_path do %>
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="#fc345c" viewBox="0 0 24 24" stroke="#eafff7">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                    </svg>
+                    <span class="btm-nav-label text-lg"><%= t('bottom_navi.statics') %></span>
+                  <% end %>
+                </li>
+              </ul>
+            </div>
+          <% end %>
         <% end %>
       </div>
       <!-- サイドバー -->

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :head do %>
     <title>プロフィールの編集 | PowerLifter's Log</title>
 <% end %>
-<div class="hero min-h-screen bg-base-200">
+<div class="container mx-auto my-auto">
   <div class="hero-content flex-col">
     <h1 class="text-2xl">プロフィール編集</h1>
     <div class="card shrink-0 w-full max-w-sm shadow-2xl bg-white">

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for :head do %>
     <title>プロフィールの登録 | PowerLifter's Log</title>
 <% end %>
-<div class="hero min-h-screen bg-base-200">
+<div class="container mx-auto my-auto">
   <div class="hero-content flex-col">
     <h1 class="text-2xl">プロフィール 登録</h1>
     <div class="card shrink-0 w-full max-w-sm shadow-2xl bg-white">


### PR DESCRIPTION
## 変更の概要

* 変更の概要
プロフィール新規登録時と編集ページのレスポンシブ対応をした
* 関連するIssueやプルリクエスト
close #269 

#### レスポンシブ対応
* [x] コンテナクラスを定義して画面のサイズに合わせて、要素の幅を自動的に調整させた
```
<div class="container mx-auto">
・・・
</dev>
```
#### サイドバーをプロフィール新規登録時に非表示にする