### PR TITLE
update: Rubocopによるコード修正(controllersディレクトリ下)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,19 @@ require:
 
 AllCops:
   NewCops: enable
+  # 何のルールに引っかかったか表示する
+  DisplayCopNames: true
+  # rubocop対象外(リポジトリ毎で調節)
+  Exclude:
+    - "Gemfile"
+    - "bin/**/*"
+    - "db/**/*"
+    - "log/**/*"
+    - "tmp/**/*"
+    - "vendor/**/*"
+    - "lib/tasks/auto_annotate_models.rake"
+    - "config/environments/*"
+    - "config/puma.rb"
 
 RSpec/ContextWording:
   Enabled: false

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,9 +8,9 @@ class ApplicationController < ActionController::Base
   private
 
   def restrict_guest_user_actions
-    if current_user&.guest? && action_name.in?(%w[new create edit update destroy])
-      redirect_to competitions_path, danger: "ゲストユーザーは新規登録・編集・削除機能を実行できません。"
-    end
+    return unless current_user&.guest? && action_name.in?(%w[new create edit update destroy])
+
+    redirect_to competitions_path, danger: 'ゲストユーザーは新規登録・編集・削除機能を実行できません。'
   end
 
   def not_authenticated

--- a/app/controllers/charts_controller.rb
+++ b/app/controllers/charts_controller.rb
@@ -1,9 +1,35 @@
 class ChartsController < ApplicationController
   def index
     @user = current_user
-    @classic_power_total_weights = view_context.format_dates_and_weights(ClassicPowerliftingTotalLiftedWeightQuery.call(@user))
-    @classic_single_benchpress_weights = view_context.format_dates_and_weights(ClassicSingleBenchPressLiftedWeightQuery.call(@user))
-    @equipped_power_total_weights = view_context.format_dates_and_weights(EquippedPowerliftingTotalLiftedWeightQuery.call(@user))
-    @equipped_single_benchpress_weights = view_context.format_dates_and_weights(EquippedSingleBenchPressLiftedWeightQuery.call(@user))
+    @classic_power_total_weights = fetch_classic_power_total_weights
+    @classic_single_benchpress_weights = fetch_classic_single_benchpress_weights
+    @equipped_power_total_weights = fetch_equipped_power_total_weights
+    @equipped_single_benchpress_weights = fetch_equipped_single_benchpress_weights
+  end
+
+  private
+
+  def fetch_classic_power_total_weights
+    view_context.format_dates_and_weights(
+      ClassicPowerliftingTotalLiftedWeightQuery.call(@user)
+    )
+  end
+
+  def fetch_classic_single_benchpress_weights
+    view_context.format_dates_and_weights(
+      ClassicSingleBenchPressLiftedWeightQuery.call(@user)
+    )
+  end
+
+  def fetch_equipped_power_total_weights
+    view_context.format_dates_and_weights(
+      EquippedPowerliftingTotalLiftedWeightQuery.call(@user)
+    )
+  end
+
+  def fetch_equipped_single_benchpress_weights
+    view_context.format_dates_and_weights(
+      EquippedSingleBenchPressLiftedWeightQuery.call(@user)
+    )
   end
 end

--- a/app/controllers/competition_records_controller.rb
+++ b/app/controllers/competition_records_controller.rb
@@ -1,6 +1,6 @@
 class CompetitionRecordsController < ApplicationController
   before_action :set_competition
-  before_action :set_competition_record, only: %i[ destroy ]
+  before_action :set_competition_record, only: %i[destroy]
 
   def destroy
     @competition_record.destroy!

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -10,8 +10,14 @@ class CompetitionsController < ApplicationController
   end
 
   def show
-    @past_competition = current_user.competitions.past_competitions(@competition.gearcategory_type,
-                                                                    @competition.category, @competition.date).order(date: :desc).first
+    @past_competition = current_user.competitions
+                                    .past_competitions(
+                                      @competition.gearcategory_type,
+                                      @competition.category,
+                                      @competition.date
+                                    )
+                                    .order(date: :desc)
+                                    .first
     @past_competition_result = @past_competition.competition_result if @past_competition.present?
   end
 
@@ -31,6 +37,7 @@ class CompetitionsController < ApplicationController
     end
   end
 
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def update
     @competition.assign_attributes(competition_params)
     if @competition.valid?
@@ -50,6 +57,7 @@ class CompetitionsController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def destroy
     @competition.destroy!

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -1,17 +1,25 @@
 class CompetitionsController < ApplicationController
-  before_action :set_competition, only: %i[ show edit update destroy ]
-  before_action :set_competition_record, only: %i[ show edit update ]
-  before_action :set_competition_result, only: %i[ show update ]
-  skip_before_action :set_bottom_navi, only: %i[ new edit ]
-  before_action :hide_bottom_navi, only: %i[ create update ]
+  before_action :set_competition, only: %i[show edit update destroy]
+  before_action :set_competition_record, only: %i[show edit update]
+  before_action :set_competition_result, only: %i[show update]
+  skip_before_action :set_bottom_navi, only: %i[new edit]
+  before_action :hide_bottom_navi, only: %i[create update]
 
   def index
     @competitions = current_user.competitions.order(date: :desc)
   end
 
+  def show
+    @past_competition = current_user.competitions.past_competitions(@competition.gearcategory_type,
+                                                                    @competition.category, @competition.date).order(date: :desc).first
+    @past_competition_result = @past_competition.competition_result if @past_competition.present?
+  end
+
   def new
     @competition = Competition.new
   end
+
+  def edit; end
 
   def create
     @competition = current_user.competitions.build(competition_params)
@@ -22,13 +30,6 @@ class CompetitionsController < ApplicationController
       render :new, status: :unprocessable_entity
     end
   end
-
-  def show
-    @past_competition = current_user.competitions.past_competitions(@competition.gearcategory_type, @competition.category, @competition.date ).order(date: :desc).first
-    @past_competition_result = @past_competition.competition_result if @past_competition.present?
-  end
-
-  def edit; end
 
   def update
     @competition.assign_attributes(competition_params)
@@ -55,10 +56,11 @@ class CompetitionsController < ApplicationController
     redirect_to competitions_path, success: t('.success')
   end
 
-private
+  private
 
   def competition_params
-    params.require(:competition).permit(:name, :venue, :date, :competition_type, :gearcategory_type, :category, :age_group, :weight_class)
+    params.require(:competition).permit(:name, :venue, :date, :competition_type, :gearcategory_type, :category,
+                                        :age_group, :weight_class)
   end
 
   def set_competition

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -2,24 +2,15 @@ class LineBotController < ApplicationController
   skip_before_action :require_login
   require 'line/bot'
   protect_from_forgery except: [:callback]
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def callback
     body = request.body.read
-    # リクエストのボディ部分全体を文字列として読み取り、body変数にいれる
     signature = request.env['HTTP_X_LINE_SIGNATURE']
-    # request.envでHTTPリクエストの環境変数を格納したハッシュから'HTTP_X_LINE_SIGNATURE'
-    # の値を取得。'HTTP_X_LINE_SIGNATURE'はリクエストの著名が含まれる
-    # LINEから送信されたWebhookリクエストが正当なものであるかを検証
-    # 著名が無効なものだったら、HTTPステータスコード400（Bad Request）を返す
     unless client.validate_signature(body, signature)
       error 400 do
         'Bad Request'
       end
     end
-    # 有効なものだった場合以下の処理が続行される
-    # イベントオブジェクトのリストを生成する
-    # Line::Bot::Event::MessageType::Textの場合、
-    # 受信したテキストメッセージの内容をそのまま
-    # 返信メッセージとして構築します。
     events = client.parse_events_from(body)
     events.each do |event|
       case event
@@ -36,6 +27,7 @@ class LineBotController < ApplicationController
     end
     head :ok
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   private
 

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -1,7 +1,7 @@
 class LineBotController < ApplicationController
   skip_before_action :require_login
   require 'line/bot'
-  protect_from_forgery :except => [:callback]
+  protect_from_forgery except: [:callback]
   def callback
     body = request.body.read
     # リクエストのボディ部分全体を文字列として読み取り、body変数にいれる
@@ -11,7 +11,9 @@ class LineBotController < ApplicationController
     # LINEから送信されたWebhookリクエストが正当なものであるかを検証
     # 著名が無効なものだったら、HTTPステータスコード400（Bad Request）を返す
     unless client.validate_signature(body, signature)
-      error 400 do 'Bad Request' end
+      error 400 do
+        'Bad Request'
+      end
     end
     # 有効なものだった場合以下の処理が続行される
     # イベントオブジェクトのリストを生成する
@@ -38,10 +40,10 @@ class LineBotController < ApplicationController
   private
 
   def client
-    @client ||= Line::Bot::Client.new { |config|
+    @client ||= Line::Bot::Client.new do |config|
       config.channel_id = Rails.application.credentials.dig(:linebot, :channel_id)
       config.channel_secret = Rails.application.credentials.dig(:linebot, :channel_secret)
       config.channel_token = Rails.application.credentials.dig(:linebot, :channel_token)
-    }
+    end
   end
 end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -4,9 +4,10 @@ class OauthsController < ApplicationController
     login_at(params[:provider])
   end
 
+  # rubocop:disable Metrics/MethodLength
   def callback
-    provider = auth_params[:provider] #ストロングパラメータで受け取り
-    if @user = login_from(provider)
+    provider = auth_params[:provider] # ストロングパラメータで受け取り
+    if (@user = login_from(provider))
       redirect_to profile_existence_path, success: t('.success')
     else
       begin
@@ -14,11 +15,12 @@ class OauthsController < ApplicationController
         reset_session # protect from session fixation attack
         auto_login(@user)
         redirect_to profile_existence_path, success: t('.success')
-      rescue
+      rescue # rubocop:disable Style/RescueStandardError
         redirect_to root_path, danger: t('.danger')
       end
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   private
 

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -15,6 +15,7 @@ class PasswordResetsController < ApplicationController
     redirect_to login_path, success: t('.success')
   end
 
+  # rubocop:disable Metrics/AbcSize
   def update
     @token = params[:id]
     @user = User.load_from_reset_password_token(@token)
@@ -28,4 +29,5 @@ class PasswordResetsController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,27 +1,20 @@
 class PasswordResetsController < ApplicationController
   skip_before_action :require_login
 
-  # PWリセット申請ページを表示する
   def new; end
 
-  # ユーザーがパスワードリセットフォームにメールアドレスを入力して送信したときに実行
+  def edit
+    @token = params[:id]
+    @user = User.load_from_reset_password_token(@token)
+    not_authenticated if @user.blank?
+  end
+
   def create
     @user = User.find_by(email: params[:email])
     @user&.deliver_reset_password_instructions!
     redirect_to login_path, success: t('.success')
   end
 
-  # パスワード再設定フォーム。受信したメールのリンクから実行される
-  # トークンでユーザーを検索し、有効期限もチェック
-  # トークンが見つかり, 有効であればそのユーザーを返す
-  def edit
-    @token = params[:id]
-    @user = User.load_from_reset_password_token(@token)
-    not_authenticated if @user.blank?
-    # 認証されていないユーザーを拒否する root_pathに返す
-  end
-
-  #ユーザーがパスワードリセットフォームを送信したときに実行されます。
   def update
     @token = params[:id]
     @user = User.load_from_reset_password_token(@token)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,8 +1,8 @@
 class ProfilesController < ApplicationController
-  skip_before_action :set_header_navi, only: %i[ new ]
-  before_action :hide_header_navi, only: %i[ create ]
-  skip_before_action :set_bottom_navi, only: %i[ new edit ]
-  before_action :hide_bottom_navi, only: %i[ create update ]
+  skip_before_action :set_header_navi, only: %i[new]
+  before_action :hide_header_navi, only: %i[create]
+  skip_before_action :set_bottom_navi, only: %i[new edit]
+  before_action :hide_bottom_navi, only: %i[create update]
   def existence
     if current_user.profile.present?
       # プロフィールが存在する場合,大会結果一覧へ
@@ -13,8 +13,17 @@ class ProfilesController < ApplicationController
     end
   end
 
+  def show
+    @profile = current_user.profile
+    @user = current_user
+  end
+
   def new
     @profile = Profile.new
+  end
+
+  def edit
+    @user = current_user
   end
 
   def create
@@ -25,15 +34,6 @@ class ProfilesController < ApplicationController
       flash.now[:danger] = t('.danger')
       render :new, status: :unprocessable_entity
     end
-  end
-
-  def show
-    @profile = current_user.profile
-    @user = current_user
-  end
-
-  def edit
-    @user = current_user
   end
 
   def update
@@ -53,6 +53,6 @@ class ProfilesController < ApplicationController
   end
 
   def update_user_params
-    params.require(:user).permit(:name, profile_attributes: [:gender, :birthday, :id])
+    params.require(:user).permit(:name, profile_attributes: %i[gender birthday id])
   end
 end

--- a/app/controllers/record/bench_presses_controller.rb
+++ b/app/controllers/record/bench_presses_controller.rb
@@ -21,9 +21,10 @@ module Record
       )
     end
 
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def create
       @bench_press = Record::BenchPress.new(bench_press_params)
-      if @bench_press.valid? # 手動でバリデーションの検証をする
+      if @bench_press.valid?
         session[:record].merge!({
                                   benchpress_first_attempt: @bench_press.benchpress_first_attempt,
                                   benchpress_second_attempt: @bench_press.benchpress_second_attempt,
@@ -34,18 +35,19 @@ module Record
                                 })
         case @competition.category
         when 'パワーリフティング'
-          redirect_to new_competition_deadlift_path, success: t('.success') # デッドリフトへ
+          redirect_to new_competition_deadlift_path, success: t('.success')
         when 'シングルベンチプレス'
-          redirect_to new_competition_comment_path, success: t('.success') # コメントへ
+          redirect_to new_competition_comment_path, success: t('.success')
         end
       else
         flash.now[:danger] = t('.danger')
         render :new, status: :unprocessable_entity
       end
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def update
-      # ユーザーが入力した値を取得
       @bench_press = Record::BenchPress.new(bench_press_params)
       bench_press_update_params = {
         benchpress_first_attempt: @bench_press.benchpress_first_attempt,
@@ -55,19 +57,17 @@ module Record
         benchpress_second_attempt_result: @bench_press.benchpress_second_attempt_result,
         benchpress_third_attempt_result: @bench_press.benchpress_third_attempt_result
       }
-      # 取得したレコードの属性の値を入力フォームから受け取った値に変更する
       @competition_record.assign_attributes(bench_press_update_params)
-      # バリデーション実行
       if @competition_record.valid?
         gender = current_user.profile.gender
-        # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
         @competition_record.result_save(@competition_record, @competition, gender)
-        redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
+        redirect_to competition_path(@competition), success: t('.success')
       else
         flash.now[:danger] = t('.danger')
         render :edit, status: :unprocessable_entity
       end
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     private
 

--- a/app/controllers/record/bench_presses_controller.rb
+++ b/app/controllers/record/bench_presses_controller.rb
@@ -1,91 +1,94 @@
-class Record::BenchPressesController < ApplicationController
-  before_action :set_competition
-  before_action :set_competition_record, only: %i[ edit update ]
-  before_action :set_competition_result, only: %i[ update ]
-  skip_before_action :set_bottom_navi, only: %i[ new edit ]
-  before_action :hide_bottom_navi, only: %i[ create update ]
+module Record
+  class BenchPressesController < ApplicationController
+    before_action :set_competition
+    before_action :set_competition_record, only: %i[edit update]
+    before_action :set_competition_result, only: %i[update]
+    skip_before_action :set_bottom_navi, only: %i[new edit]
+    before_action :hide_bottom_navi, only: %i[create update]
 
-  def new
-    @bench_press = Record::BenchPress.new
-  end
+    def new
+      @bench_press = Record::BenchPress.new
+    end
 
-  def create
-    @bench_press = Record::BenchPress.new(bench_press_params)
-    if @bench_press.valid? # 手動でバリデーションの検証をする
-      session[:record].merge!({
+    def edit
+      @bench_press = Record::BenchPress.new(
+        benchpress_first_attempt: @competition_record.benchpress_first_attempt,
+        benchpress_second_attempt: @competition_record.benchpress_second_attempt,
+        benchpress_third_attempt: @competition_record.benchpress_third_attempt,
+        benchpress_first_attempt_result: @competition_record.benchpress_first_attempt_result,
+        benchpress_second_attempt_result: @competition_record.benchpress_second_attempt_result,
+        benchpress_third_attempt_result: @competition_record.benchpress_third_attempt_result
+      )
+    end
+
+    def create
+      @bench_press = Record::BenchPress.new(bench_press_params)
+      if @bench_press.valid? # 手動でバリデーションの検証をする
+        session[:record].merge!({
+                                  benchpress_first_attempt: @bench_press.benchpress_first_attempt,
+                                  benchpress_second_attempt: @bench_press.benchpress_second_attempt,
+                                  benchpress_third_attempt: @bench_press.benchpress_third_attempt,
+                                  benchpress_first_attempt_result: @bench_press.benchpress_first_attempt_result,
+                                  benchpress_second_attempt_result: @bench_press.benchpress_second_attempt_result,
+                                  benchpress_third_attempt_result: @bench_press.benchpress_third_attempt_result
+                                })
+        case @competition.category
+        when 'パワーリフティング'
+          redirect_to new_competition_deadlift_path, success: t('.success') # デッドリフトへ
+        when 'シングルベンチプレス'
+          redirect_to new_competition_comment_path, success: t('.success') # コメントへ
+        end
+      else
+        flash.now[:danger] = t('.danger')
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def update
+      # ユーザーが入力した値を取得
+      @bench_press = Record::BenchPress.new(bench_press_params)
+      bench_press_update_params = {
         benchpress_first_attempt: @bench_press.benchpress_first_attempt,
         benchpress_second_attempt: @bench_press.benchpress_second_attempt,
         benchpress_third_attempt: @bench_press.benchpress_third_attempt,
         benchpress_first_attempt_result: @bench_press.benchpress_first_attempt_result,
         benchpress_second_attempt_result: @bench_press.benchpress_second_attempt_result,
         benchpress_third_attempt_result: @bench_press.benchpress_third_attempt_result
-      })
-      case @competition.category
-        when "パワーリフティング"
-          redirect_to new_competition_deadlift_path, success: t('.success') # デッドリフトへ
-        when "シングルベンチプレス"
-          redirect_to new_competition_comment_path, success: t('.success') # コメントへ
+      }
+      # 取得したレコードの属性の値を入力フォームから受け取った値に変更する
+      @competition_record.assign_attributes(bench_press_update_params)
+      # バリデーション実行
+      if @competition_record.valid?
+        gender = current_user.profile.gender
+        # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
+        @competition_record.result_save(@competition_record, @competition, gender)
+        redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
+      else
+        flash.now[:danger] = t('.danger')
+        render :edit, status: :unprocessable_entity
       end
-    else
-      flash.now[:danger] = t('.danger')
-      render :new, status: :unprocessable_entity
     end
-  end
 
-  def edit
-    @bench_press = Record::BenchPress.new(
-      benchpress_first_attempt: @competition_record.benchpress_first_attempt,
-      benchpress_second_attempt: @competition_record.benchpress_second_attempt,
-      benchpress_third_attempt: @competition_record.benchpress_third_attempt,
-      benchpress_first_attempt_result: @competition_record.benchpress_first_attempt_result,
-      benchpress_second_attempt_result: @competition_record.benchpress_second_attempt_result,
-      benchpress_third_attempt_result: @competition_record.benchpress_third_attempt_result
-  )
-  end
+    private
 
-  def update
-    # ユーザーが入力した値を取得
-    @bench_press = Record::BenchPress.new(bench_press_params)
-    bench_press_update_params = {
-      benchpress_first_attempt: @bench_press.benchpress_first_attempt,
-      benchpress_second_attempt: @bench_press.benchpress_second_attempt,
-      benchpress_third_attempt: @bench_press.benchpress_third_attempt,
-      benchpress_first_attempt_result: @bench_press.benchpress_first_attempt_result,
-      benchpress_second_attempt_result: @bench_press.benchpress_second_attempt_result,
-      benchpress_third_attempt_result: @bench_press.benchpress_third_attempt_result
-    }
-    # 取得したレコードの属性の値を入力フォームから受け取った値に変更する
-    @competition_record.assign_attributes(bench_press_update_params)
-    # バリデーション実行
-    if @competition_record.valid?
-      gender = current_user.profile.gender
-      # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
-      @competition_record.result_save(@competition_record, @competition, gender)
-      redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
-    else
-      flash.now[:danger] = t('.danger')
-      render :edit, status: :unprocessable_entity
+    def bench_press_params
+      params.require(:record_bench_press).permit(
+        :benchpress_first_attempt, :benchpress_first_attempt_result,
+        :benchpress_second_attempt, :benchpress_second_attempt_result,
+        :benchpress_third_attempt, :benchpress_third_attempt_result
+      )
     end
-  end
 
-  private
+    def set_competition
+      @competition = current_user.competitions.find(params[:competition_id])
+    end
 
-  def bench_press_params
-    params.require(:record_bench_press).permit(
-    :benchpress_first_attempt, :benchpress_first_attempt_result,
-    :benchpress_second_attempt, :benchpress_second_attempt_result,
-    :benchpress_third_attempt, :benchpress_third_attempt_result)
-  end
+    def set_competition_record
+      @competition_record = @competition.competition_record
+    end
 
-  def set_competition
-    @competition = current_user.competitions.find(params[:competition_id])
-  end
-
-  def set_competition_record
-    @competition_record = @competition.competition_record
-  end
-
-  def set_competition_result
-    @competition_result = @competition_record.competition_result
+    def set_competition_result
+      @competition_result = @competition_record.competition_result
+    end
   end
 end

--- a/app/controllers/record/comments_controller.rb
+++ b/app/controllers/record/comments_controller.rb
@@ -13,6 +13,7 @@ module Record
       @comment = Record::Comment.new(comment: @competition_record.comment)
     end
 
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def create
       @comment = Record::Comment.new(comment_params)
       if @comment.valid?
@@ -30,6 +31,7 @@ module Record
         render :new, status: :unprocessable_entity
       end
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     def update
       @comment = Record::Comment.new(comment_params)

--- a/app/controllers/record/deadlifts_controller.rb
+++ b/app/controllers/record/deadlifts_controller.rb
@@ -1,86 +1,89 @@
-class Record::DeadliftsController < ApplicationController
-  before_action :set_competition
-  before_action :set_competition_record, only: %i[ edit update ]
-  before_action :set_competition_result, only: %i[ update ]
-  skip_before_action :set_bottom_navi, only: %i[ new edit ]
-  before_action :hide_bottom_navi, only: %i[ create update ]
+module Record
+  class DeadliftsController < ApplicationController
+    before_action :set_competition
+    before_action :set_competition_record, only: %i[edit update]
+    before_action :set_competition_result, only: %i[update]
+    skip_before_action :set_bottom_navi, only: %i[new edit]
+    before_action :hide_bottom_navi, only: %i[create update]
 
-  def new
-    @deadlift = Record::Deadlift.new
-  end
+    def new
+      @deadlift = Record::Deadlift.new
+    end
 
-  def create
-    @deadlift = Record::Deadlift.new(deadlift_params)
-    if @deadlift.valid? # 手動でバリデーションの検証をする
-      session[:record].merge!({
+    def edit
+      @deadlift = Record::Deadlift.new(
+        deadlift_first_attempt: @competition_record.deadlift_first_attempt,
+        deadlift_second_attempt: @competition_record.deadlift_second_attempt,
+        deadlift_third_attempt: @competition_record.deadlift_third_attempt,
+        deadlift_first_attempt_result: @competition_record.deadlift_first_attempt_result,
+        deadlift_second_attempt_result: @competition_record.deadlift_second_attempt_result,
+        deadlift_third_attempt_result: @competition_record.deadlift_third_attempt_result
+      )
+    end
+
+    def create
+      @deadlift = Record::Deadlift.new(deadlift_params)
+      if @deadlift.valid? # 手動でバリデーションの検証をする
+        session[:record].merge!({
+                                  deadlift_first_attempt: @deadlift.deadlift_first_attempt,
+                                  deadlift_second_attempt: @deadlift.deadlift_second_attempt,
+                                  deadlift_third_attempt: @deadlift.deadlift_third_attempt,
+                                  deadlift_first_attempt_result: @deadlift.deadlift_first_attempt_result,
+                                  deadlift_second_attempt_result: @deadlift.deadlift_second_attempt_result,
+                                  deadlift_third_attempt_result: @deadlift.deadlift_third_attempt_result
+                                })
+        redirect_to new_competition_comment_path, success: t('.success') # 次のステップへ遷移
+      else
+        flash.now[:danger] = t('.danger')
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def update
+      # ユーザーが入力した値を取得
+      @deadlift = Record::Deadlift.new(deadlift_params)
+      deadlift_update_params = {
         deadlift_first_attempt: @deadlift.deadlift_first_attempt,
         deadlift_second_attempt: @deadlift.deadlift_second_attempt,
         deadlift_third_attempt: @deadlift.deadlift_third_attempt,
         deadlift_first_attempt_result: @deadlift.deadlift_first_attempt_result,
         deadlift_second_attempt_result: @deadlift.deadlift_second_attempt_result,
         deadlift_third_attempt_result: @deadlift.deadlift_third_attempt_result
-      })
-      redirect_to new_competition_comment_path, success: t('.success') # 次のステップへ遷移
-    else
-      flash.now[:danger] = t('.danger')
-      render :new, status: :unprocessable_entity
+      }
+      # 取得したレコードの属性の値を入力フォームから受け取った値に変更する
+      @competition_record.assign_attributes(deadlift_update_params)
+      # バリデーション実行
+      if @competition_record.valid?
+        gender = current_user.profile.gender
+        # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
+        @competition_record.result_save(@competition_record, @competition, gender)
+        redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
+      else
+        flash.now[:danger] = t('.danger')
+        render :edit, status: :unprocessable_entity
+      end
     end
-  end
 
-  def edit
-    @deadlift = Record::Deadlift.new(
-      deadlift_first_attempt: @competition_record.deadlift_first_attempt,
-      deadlift_second_attempt: @competition_record.deadlift_second_attempt,
-      deadlift_third_attempt: @competition_record.deadlift_third_attempt,
-      deadlift_first_attempt_result: @competition_record.deadlift_first_attempt_result,
-      deadlift_second_attempt_result: @competition_record.deadlift_second_attempt_result,
-      deadlift_third_attempt_result: @competition_record.deadlift_third_attempt_result
-    )
-  end
+    private
 
-  def update
-    # ユーザーが入力した値を取得
-    @deadlift = Record::Deadlift.new(deadlift_params)
-    deadlift_update_params = {
-      deadlift_first_attempt: @deadlift.deadlift_first_attempt,
-      deadlift_second_attempt: @deadlift.deadlift_second_attempt,
-      deadlift_third_attempt: @deadlift.deadlift_third_attempt,
-      deadlift_first_attempt_result: @deadlift.deadlift_first_attempt_result,
-      deadlift_second_attempt_result: @deadlift.deadlift_second_attempt_result,
-      deadlift_third_attempt_result: @deadlift.deadlift_third_attempt_result
-    }
-    # 取得したレコードの属性の値を入力フォームから受け取った値に変更する
-    @competition_record.assign_attributes(deadlift_update_params)
-    # バリデーション実行
-    if @competition_record.valid?
-      gender = current_user.profile.gender
-      # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
-      @competition_record.result_save(@competition_record, @competition, gender)
-      redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
-    else
-      flash.now[:danger] = t('.danger')
-      render :edit, status: :unprocessable_entity
+    def deadlift_params
+      params.require(:record_deadlift).permit(
+        :deadlift_first_attempt, :deadlift_first_attempt_result,
+        :deadlift_second_attempt, :deadlift_second_attempt_result,
+        :deadlift_third_attempt, :deadlift_third_attempt_result
+      )
     end
-  end
 
-  private
+    def set_competition
+      @competition = current_user.competitions.find(params[:competition_id])
+    end
 
-  def deadlift_params
-    params.require(:record_deadlift).permit(
-    :deadlift_first_attempt, :deadlift_first_attempt_result,
-    :deadlift_second_attempt, :deadlift_second_attempt_result,
-    :deadlift_third_attempt, :deadlift_third_attempt_result)
-  end
+    def set_competition_record
+      @competition_record = @competition.competition_record
+    end
 
-  def set_competition
-    @competition = current_user.competitions.find(params[:competition_id])
-  end
-
-  def set_competition_record
-    @competition_record = @competition.competition_record
-  end
-
-  def set_competition_result
-    @competition_result = @competition_record.competition_result
+    def set_competition_result
+      @competition_result = @competition_record.competition_result
+    end
   end
 end

--- a/app/controllers/record/deadlifts_controller.rb
+++ b/app/controllers/record/deadlifts_controller.rb
@@ -21,6 +21,7 @@ module Record
       )
     end
 
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def create
       @deadlift = Record::Deadlift.new(deadlift_params)
       if @deadlift.valid? # 手動でバリデーションの検証をする
@@ -38,7 +39,9 @@ module Record
         render :new, status: :unprocessable_entity
       end
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def update
       # ユーザーが入力した値を取得
       @deadlift = Record::Deadlift.new(deadlift_params)
@@ -63,6 +66,7 @@ module Record
         render :edit, status: :unprocessable_entity
       end
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     private
 

--- a/app/controllers/record/squats_controller.rb
+++ b/app/controllers/record/squats_controller.rb
@@ -21,9 +21,10 @@ module Record
       )
     end
 
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def create
       @squat = Record::Squat.new(squat_params)
-      if @squat.valid? # 手動でバリデーションの検証をする
+      if @squat.valid?
         session[:record].merge!({
                                   squat_first_attempt: @squat.squat_first_attempt,
                                   squat_second_attempt: @squat.squat_second_attempt,
@@ -32,15 +33,16 @@ module Record
                                   squat_second_attempt_result: @squat.squat_second_attempt_result,
                                   squat_third_attempt_result: @squat.squat_third_attempt_result
                                 })
-        redirect_to new_competition_bench_presse_path, success: t('.success') # 次のステップへ遷移
+        redirect_to new_competition_bench_presse_path, success: t('.success')
       else
         flash.now[:danger] = t('.danger')
         render :new, status: :unprocessable_entity
       end
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def update
-      # ユーザーが入力した値を取得
       @squat = Record::Squat.new(squat_params)
       squat_update_params = {
         squat_first_attempt: @squat.squat_first_attempt,
@@ -50,19 +52,17 @@ module Record
         squat_second_attempt_result: @squat.squat_second_attempt_result,
         squat_third_attempt_result: @squat.squat_third_attempt_result
       }
-      # 取得したレコードの属性の値を入力フォームから受け取った値に変更する
       @competition_record.assign_attributes(squat_update_params)
-      # バリデーション実行
       if @competition_record.valid?
         gender = current_user.profile.gender
-        # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
         @competition_record.result_save(@competition_record, @competition, gender)
-        redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
+        redirect_to competition_path(@competition), success: t('.success')
       else
         flash.now[:danger] = t('.danger')
         render :edit, status: :unprocessable_entity
       end
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     private
 

--- a/app/controllers/record/squats_controller.rb
+++ b/app/controllers/record/squats_controller.rb
@@ -1,87 +1,89 @@
-class Record::SquatsController < ApplicationController
-  before_action :set_competition
-  before_action :set_competition_record, only: %i[ edit update ]
-  before_action :set_competition_result, only: %i[ update ]
-  skip_before_action :set_bottom_navi, only: %i[ new edit ]
-  before_action :hide_bottom_navi, only: %i[ create update ]
+module Record
+  class SquatsController < ApplicationController
+    before_action :set_competition
+    before_action :set_competition_record, only: %i[edit update]
+    before_action :set_competition_result, only: %i[update]
+    skip_before_action :set_bottom_navi, only: %i[new edit]
+    before_action :hide_bottom_navi, only: %i[create update]
 
-  def new
-    @squat = Record::Squat.new
-  end
+    def new
+      @squat = Record::Squat.new
+    end
 
-  def create
-    @squat = Record::Squat.new(squat_params)
-    if @squat.valid? # 手動でバリデーションの検証をする
-      session[:record].merge!({
+    def edit
+      @squat = Record::Squat.new(
+        squat_first_attempt: @competition_record.squat_first_attempt,
+        squat_second_attempt: @competition_record.squat_second_attempt,
+        squat_third_attempt: @competition_record.squat_third_attempt,
+        squat_first_attempt_result: @competition_record.squat_first_attempt_result,
+        squat_second_attempt_result: @competition_record.squat_second_attempt_result,
+        squat_third_attempt_result: @competition_record.squat_third_attempt_result
+      )
+    end
+
+    def create
+      @squat = Record::Squat.new(squat_params)
+      if @squat.valid? # 手動でバリデーションの検証をする
+        session[:record].merge!({
+                                  squat_first_attempt: @squat.squat_first_attempt,
+                                  squat_second_attempt: @squat.squat_second_attempt,
+                                  squat_third_attempt: @squat.squat_third_attempt,
+                                  squat_first_attempt_result: @squat.squat_first_attempt_result,
+                                  squat_second_attempt_result: @squat.squat_second_attempt_result,
+                                  squat_third_attempt_result: @squat.squat_third_attempt_result
+                                })
+        redirect_to new_competition_bench_presse_path, success: t('.success') # 次のステップへ遷移
+      else
+        flash.now[:danger] = t('.danger')
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def update
+      # ユーザーが入力した値を取得
+      @squat = Record::Squat.new(squat_params)
+      squat_update_params = {
         squat_first_attempt: @squat.squat_first_attempt,
         squat_second_attempt: @squat.squat_second_attempt,
         squat_third_attempt: @squat.squat_third_attempt,
         squat_first_attempt_result: @squat.squat_first_attempt_result,
         squat_second_attempt_result: @squat.squat_second_attempt_result,
         squat_third_attempt_result: @squat.squat_third_attempt_result
-      })
-      redirect_to new_competition_bench_presse_path, success: t('.success') # 次のステップへ遷移
-    else
-      flash.now[:danger] = t('.danger')
-      render :new, status: :unprocessable_entity
+      }
+      # 取得したレコードの属性の値を入力フォームから受け取った値に変更する
+      @competition_record.assign_attributes(squat_update_params)
+      # バリデーション実行
+      if @competition_record.valid?
+        gender = current_user.profile.gender
+        # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
+        @competition_record.result_save(@competition_record, @competition, gender)
+        redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
+      else
+        flash.now[:danger] = t('.danger')
+        render :edit, status: :unprocessable_entity
+      end
     end
-  end
 
-  def edit
-    @squat = Record::Squat.new(
-    squat_first_attempt: @competition_record.squat_first_attempt,
-    squat_second_attempt: @competition_record.squat_second_attempt,
-    squat_third_attempt: @competition_record.squat_third_attempt,
-    squat_first_attempt_result: @competition_record.squat_first_attempt_result,
-    squat_second_attempt_result: @competition_record.squat_second_attempt_result,
-    squat_third_attempt_result: @competition_record.squat_third_attempt_result
-  )
-  end
+    private
 
-  def update
-    # ユーザーが入力した値を取得
-    @squat = Record::Squat.new(squat_params)
-    squat_update_params = {
-      squat_first_attempt: @squat.squat_first_attempt,
-      squat_second_attempt: @squat.squat_second_attempt,
-      squat_third_attempt: @squat.squat_third_attempt,
-      squat_first_attempt_result: @squat.squat_first_attempt_result,
-      squat_second_attempt_result: @squat.squat_second_attempt_result,
-      squat_third_attempt_result: @squat.squat_third_attempt_result
-    }
-    # 取得したレコードの属性の値を入力フォームから受け取った値に変更する
-    @competition_record.assign_attributes(squat_update_params)
-    # バリデーション実行
-    if @competition_record.valid?
-      gender = current_user.profile.gender
-      # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
-      @competition_record.result_save(@competition_record, @competition, gender)
-      redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
-    else
-      flash.now[:danger] = t('.danger')
-      render :edit, status: :unprocessable_entity
+    def squat_params
+      params.require(:record_squat).permit(
+        :squat_first_attempt, :squat_first_attempt_result,
+        :squat_second_attempt, :squat_second_attempt_result,
+        :squat_third_attempt, :squat_third_attempt_result
+      )
     end
-  end
 
-  private
+    def set_competition
+      @competition = current_user.competitions.find(params[:competition_id])
+    end
 
-  def squat_params
-    params.require(:record_squat).permit(
-    :squat_first_attempt, :squat_first_attempt_result,
-    :squat_second_attempt, :squat_second_attempt_result,
-    :squat_third_attempt, :squat_third_attempt_result)
-  end
+    def set_competition_record
+      @competition_record = @competition.competition_record
+    end
 
-  def set_competition
-    @competition = current_user.competitions.find(params[:competition_id])
-  end
-
-  def set_competition_record
-    @competition_record = @competition.competition_record
-  end
-
-  def set_competition_result
-    @competition_result = @competition_record.competition_result
+    def set_competition_result
+      @competition_result = @competition_record.competition_result
+    end
   end
 end
-

--- a/app/controllers/record/weigh_ins_controller.rb
+++ b/app/controllers/record/weigh_ins_controller.rb
@@ -14,42 +14,42 @@ module Record
       @weigh_in = Record::WeighIn.new(weight: @competition_record.weight)
     end
 
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def create
       @weigh_in = Record::WeighIn.new(weigh_in_params)
-      if @weigh_in.valid? # 手動でバリデーションの検証をする
+      if @weigh_in.valid?
         session[:record] = {
           competition_id: @weigh_in.competition_id,
           weight: @weigh_in.weight
         }
         case @competition.category
         when 'パワーリフティング'
-          redirect_to new_competition_squat_path, success: t('.success') # スクワットへ
+          redirect_to new_competition_squat_path, success: t('.success')
         when 'シングルベンチプレス'
-          redirect_to new_competition_bench_presse_path, success: t('.success') # ベンチプレスへ
+          redirect_to new_competition_bench_presse_path, success: t('.success')
         end
       else
         flash.now[:danger] = t('.danger')
         render :new, status: :unprocessable_entity
       end
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def update
-      # ユーザーが入力した値を取得
       @weigh_in = Record::WeighIn.new(weigh_in_params)
       weigh_in_uptate_params = { weight: @weigh_in.weight }
-      # 取得したレコードの属性の値を入力フォームから受け取った値に変更する
       @competition_record.assign_attributes(weigh_in_uptate_params)
-      # バリデーション実行
       if @competition_record.valid?
         gender = current_user.profile.gender
-        # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
         @competition_record.result_save(@competition_record, @competition, gender)
-        redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
+        redirect_to competition_path(@competition), success: t('.success')
       else
         flash.now[:danger] = t('.danger')
         render :edit, status: :unprocessable_entity
       end
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     private
 

--- a/app/controllers/record/weigh_ins_controller.rb
+++ b/app/controllers/record/weigh_ins_controller.rb
@@ -1,70 +1,72 @@
-class Record::WeighInsController < ApplicationController
-  before_action :set_competition
-  before_action :set_competition_record, only: %i[ edit update ]
-  before_action :set_competition_result, only: %i[ update ]
-  skip_before_action :set_bottom_navi, only: %i[ new edit ]
-  before_action :hide_bottom_navi, only: %i[ create update ]
+module Record
+  class WeighInsController < ApplicationController
+    before_action :set_competition
+    before_action :set_competition_record, only: %i[edit update]
+    before_action :set_competition_result, only: %i[update]
+    skip_before_action :set_bottom_navi, only: %i[new edit]
+    before_action :hide_bottom_navi, only: %i[create update]
 
-  def new
-    @weigh_in = Record::WeighIn.new
-  end
+    def new
+      @weigh_in = Record::WeighIn.new
+    end
 
-  def create
-    @weigh_in = Record::WeighIn.new(weigh_in_params)
-    if @weigh_in.valid? # 手動でバリデーションの検証をする
-      session[:record] = {
-        competition_id: @weigh_in.competition_id,
-        weight: @weigh_in.weight
-      }
-      case @competition.category
-        when "パワーリフティング"
+    def edit
+      @weigh_in = Record::WeighIn.new(weight: @competition_record.weight)
+    end
+
+    def create
+      @weigh_in = Record::WeighIn.new(weigh_in_params)
+      if @weigh_in.valid? # 手動でバリデーションの検証をする
+        session[:record] = {
+          competition_id: @weigh_in.competition_id,
+          weight: @weigh_in.weight
+        }
+        case @competition.category
+        when 'パワーリフティング'
           redirect_to new_competition_squat_path, success: t('.success') # スクワットへ
-        when "シングルベンチプレス"
+        when 'シングルベンチプレス'
           redirect_to new_competition_bench_presse_path, success: t('.success') # ベンチプレスへ
+        end
+      else
+        flash.now[:danger] = t('.danger')
+        render :new, status: :unprocessable_entity
       end
-    else
-      flash.now[:danger] = t('.danger')
-      render :new, status: :unprocessable_entity
     end
-  end
 
-  def edit
-    @weigh_in = Record::WeighIn.new(weight: @competition_record.weight)
-  end
-
-  def update
-    # ユーザーが入力した値を取得
-    @weigh_in = Record::WeighIn.new(weigh_in_params)
-    weigh_in_uptate_params = {weight: @weigh_in.weight}
-    # 取得したレコードの属性の値を入力フォームから受け取った値に変更する
-    @competition_record.assign_attributes(weigh_in_uptate_params)
-    # バリデーション実行
-    if @competition_record.valid?
-      gender = current_user.profile.gender
-      # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
-      @competition_record.result_save(@competition_record, @competition, gender)
-      redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
-    else
-      flash.now[:danger] = t('.danger')
-      render :edit, status: :unprocessable_entity
+    def update
+      # ユーザーが入力した値を取得
+      @weigh_in = Record::WeighIn.new(weigh_in_params)
+      weigh_in_uptate_params = { weight: @weigh_in.weight }
+      # 取得したレコードの属性の値を入力フォームから受け取った値に変更する
+      @competition_record.assign_attributes(weigh_in_uptate_params)
+      # バリデーション実行
+      if @competition_record.valid?
+        gender = current_user.profile.gender
+        # メソッド内でtransaction実行し、competition_recordとcompetition_result更新
+        @competition_record.result_save(@competition_record, @competition, gender)
+        redirect_to competition_path(@competition), success: t('.success') # 成功したら詳細ページへ遷移する
+      else
+        flash.now[:danger] = t('.danger')
+        render :edit, status: :unprocessable_entity
+      end
     end
-  end
 
-  private
+    private
 
-  def weigh_in_params
-    params.require(:record_weigh_in).permit(:weight).merge(competition_id: params[:competition_id])
-  end
+    def weigh_in_params
+      params.require(:record_weigh_in).permit(:weight).merge(competition_id: params[:competition_id])
+    end
 
-  def set_competition
-    @competition = current_user.competitions.find(params[:competition_id])
-  end
+    def set_competition
+      @competition = current_user.competitions.find(params[:competition_id])
+    end
 
-  def set_competition_record
-    @competition_record = @competition.competition_record
-  end
+    def set_competition_record
+      @competition_record = @competition.competition_record
+    end
 
-  def set_competition_result
-    @competition_result = @competition_record.competition_result
+    def set_competition_result
+      @competition_result = @competition_record.competition_result
+    end
   end
 end


### PR DESCRIPTION
## 変更の概要

- Rubocopによる、コード修正をした
- controllersディレクトリ下

* 関連するIssueやプルリクエスト
close #327 


## やったこと
* [x] 下記コマンドで自動コード修正をかけた
```
rubocop spec/ -a
rubocop spec/ -A
```
* [x] その他手動でコードを修正
* [x] .rubocop.ymlに警告を無視するディレクトリを指定
```yml
# rubocop対象外(リポジトリ毎で調節)
  Exclude:
    - "Gemfile"
    - "bin/**/*"
    - "db/**/*"
    - "log/**/*"
    - "tmp/**/*"
    - "vendor/**/*"
    - "lib/tasks/auto_annotate_models.rake"
    - "config/environments/*"
    - "config/puma.rb"
```

## やってないこと
###  以下の指摘を無効化した

- [ ] Metrics/AbcSize
- [ ] Metrics/MethodLength,

#### 理由
- テストコードを書いていないため
- リファクタリング後、データの整合性が取れなくなる事に気付けないことが懸念されるため

別issueに切り出します #333
