### PR TITLE
update: Rubocopによるコード修正(queriesディレクトリ下)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,6 @@ Style/Documentation:
 Style/Lambda:
   Enabled: false
 
+Lint/MissingSuper:
+  Exclude:
+    - 'app/queries/*'

--- a/app/queries/classic_powerlifting_ipfglpoints_query.rb
+++ b/app/queries/classic_powerlifting_ipfglpoints_query.rb
@@ -5,9 +5,9 @@ class ClassicPowerliftingIpfglpointsQuery < Query
 
   def call
     QueryBuilder.new(@user)
-      .with_competition_type(0)
-      .with_gearcategory_type(0)
-      .with_category("パワーリフティング")
-      .pluck_values("competition_results.ipf_points")
+                .with_competition_type(0)
+                .with_gearcategory_type(0)
+                .with_category('パワーリフティング')
+                .pluck_values('competition_results.ipf_points')
   end
 end

--- a/app/queries/classic_powerlifting_total_lifted_weight_query.rb
+++ b/app/queries/classic_powerlifting_total_lifted_weight_query.rb
@@ -5,9 +5,9 @@ class ClassicPowerliftingTotalLiftedWeightQuery < Query
 
   def call
     QueryBuilder.new(@user)
-      .with_competition_type(0)
-      .with_gearcategory_type(0)
-      .with_category("パワーリフティング")
-      .pluck_values("competition_results.total_lifted_weight")
+                .with_competition_type(0)
+                .with_gearcategory_type(0)
+                .with_category('パワーリフティング')
+                .pluck_values('competition_results.total_lifted_weight')
   end
 end

--- a/app/queries/classic_single_bench_press_ipfglpoints_query.rb
+++ b/app/queries/classic_single_bench_press_ipfglpoints_query.rb
@@ -5,9 +5,9 @@ class ClassicSingleBenchPressIpfglpointsQuery < Query
 
   def call
     QueryBuilder.new(@user)
-      .with_competition_type(0)
-      .with_gearcategory_type(0)
-      .with_category("シングルベンチプレス")
-      .pluck_values("competition_results.ipf_points")
+                .with_competition_type(0)
+                .with_gearcategory_type(0)
+                .with_category('シングルベンチプレス')
+                .pluck_values('competition_results.ipf_points')
   end
 end

--- a/app/queries/classic_single_bench_press_lifted_weight_query.rb
+++ b/app/queries/classic_single_bench_press_lifted_weight_query.rb
@@ -5,9 +5,9 @@ class ClassicSingleBenchPressLiftedWeightQuery < Query
 
   def call
     QueryBuilder.new(@user)
-      .with_competition_type(0)
-      .with_gearcategory_type(0)
-      .with_category("シングルベンチプレス")
-      .pluck_values("competition_results.total_lifted_weight")
+                .with_competition_type(0)
+                .with_gearcategory_type(0)
+                .with_category('シングルベンチプレス')
+                .pluck_values('competition_results.total_lifted_weight')
   end
 end

--- a/app/queries/equipped_powerlifting_ipfglpoints_query.rb
+++ b/app/queries/equipped_powerlifting_ipfglpoints_query.rb
@@ -5,9 +5,9 @@ class EquippedPowerliftingIpfglpointsQuery < Query
 
   def call
     QueryBuilder.new(@user)
-      .with_competition_type(0)
-      .with_gearcategory_type(1)
-      .with_category("パワーリフティング")
-      .pluck_values("competition_results.ipf_points")
+                .with_competition_type(0)
+                .with_gearcategory_type(1)
+                .with_category('パワーリフティング')
+                .pluck_values('competition_results.ipf_points')
   end
 end

--- a/app/queries/equipped_powerlifting_total_lifted_weight_query.rb
+++ b/app/queries/equipped_powerlifting_total_lifted_weight_query.rb
@@ -5,9 +5,9 @@ class EquippedPowerliftingTotalLiftedWeightQuery < Query
 
   def call
     QueryBuilder.new(@user)
-      .with_competition_type(0)
-      .with_gearcategory_type(1)
-      .with_category("パワーリフティング")
-      .pluck_values("competition_results.total_lifted_weight")
+                .with_competition_type(0)
+                .with_gearcategory_type(1)
+                .with_category('パワーリフティング')
+                .pluck_values('competition_results.total_lifted_weight')
   end
 end

--- a/app/queries/equipped_single_bench_press_ipfglpoints_query.rb
+++ b/app/queries/equipped_single_bench_press_ipfglpoints_query.rb
@@ -5,9 +5,9 @@ class EquippedSingleBenchPressIpfglpointsQuery < Query
 
   def call
     QueryBuilder.new(@user)
-      .with_competition_type(0)
-      .with_gearcategory_type(1)
-      .with_category("シングルベンチプレス")
-      .pluck_values("competition_results.ipf_points")
+                .with_competition_type(0)
+                .with_gearcategory_type(1)
+                .with_category('シングルベンチプレス')
+                .pluck_values('competition_results.ipf_points')
   end
 end

--- a/app/queries/equipped_single_bench_press_lifted_weight_query.rb
+++ b/app/queries/equipped_single_bench_press_lifted_weight_query.rb
@@ -5,9 +5,9 @@ class EquippedSingleBenchPressLiftedWeightQuery < Query
 
   def call
     QueryBuilder.new(@user)
-      .with_competition_type(0)
-      .with_gearcategory_type(1)
-      .with_category("シングルベンチプレス")
-      .pluck_values("competition_results.total_lifted_weight")
+                .with_competition_type(0)
+                .with_gearcategory_type(1)
+                .with_category('シングルベンチプレス')
+                .pluck_values('competition_results.total_lifted_weight')
   end
 end

--- a/app/queries/query.rb
+++ b/app/queries/query.rb
@@ -1,6 +1,6 @@
 class Query
-  def self.call(*args)
-    new(*args).call
+  def self.call(*)
+    new(*).call
   end
 
   def call

--- a/app/queries/query_builder.rb
+++ b/app/queries/query_builder.rb
@@ -1,7 +1,10 @@
 class QueryBuilder
   def initialize(user)
     @user = user
-    @relation = user.competitions.joins(competition_record: :competition_result).where(participation_status: 0).order(date: :asc)
+    @relation = user.competitions
+                    .joins(competition_record: :competition_result)
+                    .where(participation_status: 0)
+                    .order(date: :asc)
   end
 
   def with_competition_type(competition_type)

--- a/app/queries/query_builder.rb
+++ b/app/queries/query_builder.rb
@@ -1,26 +1,26 @@
 class QueryBuilder
   def initialize(user)
     @user = user
-    @relation = user.competitions.joins(:competition_record => :competition_result).where(participation_status: 0).order(date: :asc)
+    @relation = user.competitions.joins(competition_record: :competition_result).where(participation_status: 0).order(date: :asc)
   end
 
   def with_competition_type(competition_type)
-    @relation = @relation.where(competition_type: competition_type)
+    @relation = @relation.where(competition_type:)
     self
   end
 
   def with_gearcategory_type(gearcategory_type)
-    @relation = @relation.where(gearcategory_type: gearcategory_type)
+    @relation = @relation.where(gearcategory_type:)
     self
   end
 
   def with_category(category)
-    @relation = @relation.where(category: category)
+    @relation = @relation.where(category:)
     self
   end
 
   def pluck_values(column)
-    @relation.pluck("competitions.date", column)
+    @relation.pluck('competitions.date', column)
   end
 
   private


### PR DESCRIPTION
## 変更の概要

- Rubocopによる、コード修正をした
- queriesディレクトリ下

* 関連するIssueやプルリクエスト
close #329  


## やったこと
* [x] 下記コマンドで自動コード修正をかけた
```
rubocop spec/ -a
```
* [x] 設定ファイルに `Lint/MissingSuper`の無効化を追記した
'app/queries/*'ディレクトリ内だけ、`Lint/MissingSuper`の警告を無効化した

- 理由
親クラス`Query` に `initialize`メソッドが存在しないので、子クラスで `super( )`を書く必要がないから


```yaml
Lint/MissingSuper:
  Exclude:
    - 'app/queries/*'
```
