### PR TITLE
add: GitHub Actionsを導入しmainブランチにマージ時にRSpecとRubocopを自動実行させる

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -13,12 +13,12 @@ jobs:
         ports:
           - "5432:5432"
         env:
-          POSTGRES_DB: rails_test
-          POSTGRES_USER: rails
+          POSTGRES_DB: app_test
+          POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
     env:
       RAILS_ENV: test
-      DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
+      DATABASE_URL: "postgres://postgres:password@postgres:5432/app_test"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -1,0 +1,54 @@
+name: "Ruby on Rails CI"
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11-alpine
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: rails_test
+          POSTGRES_USER: rails
+          POSTGRES_PASSWORD: password
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      # Add or replace dependency steps here
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@78c01b705fd9d5ad960d432d3a0cfa341d50e410 # v1.179.1
+        with:
+          bundler-cache: true
+      # Add or replace database setup steps here
+      - name: Set up database schema
+        run: bin/rails db:schema:load
+      # Add or replace test runners here
+      - name: Run tests
+        run: bin/rake
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@78c01b705fd9d5ad960d432d3a0cfa341d50e410 # v1.179.1
+        with:
+          bundler-cache: true
+      - name: Generate binstubs
+        run: bundle binstubs bundler-audit brakeman rubocop
+      # Add or replace any other lints here
+      - name: Security audit dependencies
+        run: bin/bundler-audit --update
+      - name: Security audit application code
+        run: bin/brakeman -q -w2
+      - name: Lint Ruby files
+        run: bin/rubocop --parallel

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Set up database schema
         run: bin/rails db:schema:load
       # Add or replace test runners here
-      - name: Run tests
-        run: bin/rake
+      - name: Run RSpec tests
+        run: bin/rspec
 
   lint:
     runs-on: ubuntu-latest

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,8 @@ GEM
     nio4r (2.7.1)
     nokogiri (1.16.3-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.16.3-x86_64-linux)
+      racc (~> 1.4)
     oauth (1.1.0)
       oauth-tty (~> 1.0, >= 1.0.1)
       snaky_hash (~> 2.0)
@@ -365,6 +367,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   better_errors

--- a/config/database.yml
+++ b/config/database.yml
@@ -60,9 +60,8 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: rails_test
-  username: rails
-  password: password
+  database: app_test
+
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/database.yml
+++ b/config/database.yml
@@ -60,7 +60,9 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: app_test
+  database: rails_test
+  username: rails
+  password: password
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
## 変更の概要

* 変更の概要
GitHub ActionsのCIを導入
mainブランチにマージ時にRSpecとRubocopを自動実行させる

* 関連するIssueやプルリクエスト
feature #239 
feature #331 

## やったこと

* [x] `.github/workflows`ディレクトリに `rubyonrails.yml` を作成し、ワークフロー実行ファイルの書き込みをした
* [x] `rubyonrails.yml` は GitHub Actionsの `Ruby on Rails`テンプレートを使用した
- リポジトリのメイン ページ
- リポジトリ名の下にある  [アクション] をクリックし、そこから取得
* [x] テンプレート上のテスト実行コマンドをRspecが実行されるように変更した
```yaml
jobs:
  test:
   ・・・省略
    steps:
   ・・・省略
      - name: Run RSpec tests
        run: bin/rspec
```
* [x] database.ymlにて、テスト環境におけるデータベース設定をした
GitHub Actctionsのワークフローのデータベース環境変数と合わせた
```
test:
  <<: *default
  database: rails_test
  username: rails
  password: password
```